### PR TITLE
[Web] クエスト一覧で今日の曜日のクエストのみ表示するよう修正する。

### DIFF
--- a/src/features/quests/components/QuestsPresenter.tsx
+++ b/src/features/quests/components/QuestsPresenter.tsx
@@ -1,11 +1,20 @@
 import { QuestBoard } from "./QuestBoard";
 import { QuestList } from "./QuestList";
-import { formatDateJP, getTodayDate, now } from "../../../pkg/util/dayjs";
+import { formatDateJP, getToday, getTodayEng, now } from "../../../pkg/util/dayjs";
 import { useQueryQuestList } from "../api/quest/hooks/useQueryQuest";
 import { QuestBoardNoData } from "./QuestBoardNoData";
 import { useState } from "react";
 import { QuestListNoData } from "./QuestListNoData";
 import { Quest } from "../../../api/quest/model";
+
+const filterQuestsByDayOfTheWeek = (questList: Quest[]) => {
+  const todaysDayOfTheWeek = getTodayEng().toUpperCase();
+
+  return questList.filter((quest) => {
+    const isToday: boolean = quest.days.some((day) => day === todaysDayOfTheWeek);
+    return isToday ? quest : null;
+  });
+};
 
 const sortQuestsByTime = (questList: Quest[]) => {
   return questList.sort((a, b) => {
@@ -15,8 +24,12 @@ const sortQuestsByTime = (questList: Quest[]) => {
 
 export const QuestsPresenter = () => {
   const { data, isLoading } = useQueryQuestList();
+
+  // 曜日でフィルターする
+  const filteredQuestsData = filterQuestsByDayOfTheWeek(data ?? []);
+
   // 時間順でソートする
-  const sortedQuestsData = sortQuestsByTime(data ?? []);
+  const sortedQuestsData = sortQuestsByTime(filteredQuestsData);
 
   const nextQuestList = sortedQuestsData.filter((value) => value.state === "INACTIVE");
   const finishedQuestList = sortedQuestsData.filter((value) => value.state === "ACTIVE");
@@ -28,7 +41,7 @@ export const QuestsPresenter = () => {
     <>
       <h1 className="text-xl font-bold">
         {formatDateJP(now())}
-        {`(${getTodayDate()})`}のクエスト
+        {`(${getToday()})`}のクエスト
       </h1>
       {isLoading ? (
         <div>Loading...</div>

--- a/src/pkg/util/dayjs.ts
+++ b/src/pkg/util/dayjs.ts
@@ -27,6 +27,10 @@ export const formatDateJP = (date: string) => {
   return dayjs(date).format("YYYY年MM月DD日");
 };
 
-export const getTodayDate = () => {
+export const getToday = () => {
   return dayjs().format("ddd");
+};
+
+export const getTodayEng = () => {
+  return dayjs().locale("en").format("ddd");
 };


### PR DESCRIPTION
## 関連 issue
#56 [Web] クエスト一覧で今日の曜日のクエストのみ表示するよう修正する。

## 説明

タイトルの通りです！

## 動作確認手順

クエストをテスト日の曜日を含むものと含まないものを作成して、
きちんとテスト日の曜日だけのものが表示されているか、確認お願いします！

## 相談したいこと

## 確認して欲しいこと

## 参考 URL 等
