### PR TITLE
[Web] 曜日をstringで持つように

### DIFF
--- a/src/features/manage/common/constant/constant.ts
+++ b/src/features/manage/common/constant/constant.ts
@@ -1,4 +1,4 @@
-import { Difficulty } from "../../../../api/quest/types";
+import { Day, Difficulty } from "../../../../api/quest/types";
 
-export const DAYS = ["月", "火", "水", "木", "金", "土", "日"];
+export const DAYS: Day[] = ["MON", "TUE", "WED", "THU", "FRI", "SAT", "SUN"];
 export const DIFFICULTIES: Difficulty[] = ["EASY", "NORMAL", "HARD"];

--- a/src/features/manage/edit/components/EditPresenter.tsx
+++ b/src/features/manage/edit/components/EditPresenter.tsx
@@ -11,8 +11,8 @@ import { TManageValidationSchema, manageValidationSchema } from "../../common/li
 import { formatDateToTime } from "../../../../pkg/util/dayjs";
 import { ConfirmModal } from "../../../common/components/ConfirmModal";
 import { DAYS } from "../../common/constant/constant";
-import { convertNumberToWeekday, convertWeekdayToNumber } from "../../common/funcs";
-import { Difficulty } from "../../../../api/quest/types";
+import { convertEnToJPWeekday } from "../../common/funcs";
+import { Day, Difficulty } from "../../../../api/quest/types";
 
 type NewValues = {
   title: string;
@@ -25,6 +25,7 @@ type NewValues = {
 type Props = {
   quest_id: string;
 };
+
 export const EditPresenter: FC<Props> = (props) => {
   const { quest_id } = props;
   const navigate = useNavigate();
@@ -34,22 +35,12 @@ export const EditPresenter: FC<Props> = (props) => {
   const targetQuest = data?.find((v) => v.id === quest_id);
 
   const [difficulty, setDifficulty] = useState<Difficulty>("EASY");
-  // const [days, setDays] = useState<number[]>([]);
 
   useEffect(() => {
-    const modifiedDays = targetQuest?.days.map((v) => convertWeekdayToNumber(v).toString()) ?? [];
+    const modifiedDays = targetQuest?.days ?? [];
     setValue("days", modifiedDays);
     setDifficulty(targetQuest?.difficulty ?? "EASY");
   }, [isLoading]);
-
-  // const handleDays = (day: number) => {
-  //   if (days.some((v) => v === day)) {
-  //     const newDays = days.filter((v) => v !== day);
-  //     setDays(newDays);
-  //   } else {
-  //     setDays([day, ...days]);
-  //   }
-  // };
 
   const {
     register,
@@ -62,8 +53,6 @@ export const EditPresenter: FC<Props> = (props) => {
     resolver: zodResolver(manageValidationSchema),
   });
   const onSubmit = async (data: NewValues) => {
-    const days = data.days.map(Number);
-    const modifiedDays = days.sort().map((v) => convertNumberToWeekday(v));
     await updateQuestMutation.mutateAsync({
       id: quest_id,
       title: data.title,
@@ -72,7 +61,7 @@ export const EditPresenter: FC<Props> = (props) => {
       tagId: "",
       minutes: Number(data.minutes),
       difficulty: difficulty,
-      days: modifiedDays,
+      days: data.days as Day[],
     });
     navigate({ to: "/quests/manage" });
   };
@@ -155,8 +144,16 @@ export const EditPresenter: FC<Props> = (props) => {
               <div className="my-2">
                 <p className="block my-2">実施頻度</p>
                 <div className="flex mt-4 gap-1">
-                  {DAYS.map((v, i) => {
-                    return <NewDayOfTheWeek key={i} day={v} value={i + 1} register={register} watch={watch} />;
+                  {DAYS.map((day, i) => {
+                    return (
+                      <NewDayOfTheWeek
+                        key={i}
+                        day={convertEnToJPWeekday(day)}
+                        value={day}
+                        register={register}
+                        watch={watch}
+                      />
+                    );
                   })}
                 </div>
                 {errors.days && <FormErrorMsg msg={errors.days.message ?? ""} />}

--- a/src/features/manage/new/components/NewDayOfTheWeek.tsx
+++ b/src/features/manage/new/components/NewDayOfTheWeek.tsx
@@ -1,19 +1,19 @@
 import { FC } from "react";
 import { UseFormRegister, UseFormWatch } from "react-hook-form";
 import { TManageValidationSchema } from "../../common/libs/validation";
+import { Day } from "../../../../api/quest/types";
 
 type Props = {
-  // handleDays: (day: number) => void;
   day: string;
-  // days: number[];
-  value: number;
+  value: Day;
   register: UseFormRegister<TManageValidationSchema>;
   watch: UseFormWatch<TManageValidationSchema>;
 };
 
 export const NewDayOfTheWeek: FC<Props> = ({ day, value, register, watch }) => {
   const days = watch("days");
-  const isChecked = Array.isArray(days) && days.some((v: string) => v === value.toString());
+  const isChecked = Array.isArray(days) && days.some((v: string) => v === value);
+
   return (
     <>
       <input type="checkbox" className="hidden peer" value={value} id={`${value}`} {...register("days")} />

--- a/src/features/manage/new/components/NewPresenter.tsx
+++ b/src/features/manage/new/components/NewPresenter.tsx
@@ -8,8 +8,8 @@ import { useMutateQuest } from "../../api/quest/hooks/useMutateQuest";
 import { useNavigate } from "@tanstack/react-router";
 import { TManageValidationSchema, manageValidationSchema } from "../../common/libs/validation";
 import { DAYS } from "../../common/constant/constant";
-import { convertNumberToWeekday } from "../../common/funcs";
-import { Difficulty } from "../../../../api/quest/types";
+import { convertEnToJPWeekday } from "../../common/funcs";
+import { Day, Difficulty } from "../../../../api/quest/types";
 
 type NewValues = {
   title: string;
@@ -39,8 +39,6 @@ export const NewPresenter = () => {
     },
   });
   const onSubmit = async (data: NewValues) => {
-    const days = data.days.map(Number);
-    const modifiedDays = days.sort().map((v) => convertNumberToWeekday(v));
     await createQuestMutation.mutateAsync({
       title: data.title,
       description: data.description,
@@ -48,7 +46,7 @@ export const NewPresenter = () => {
       tagId: "",
       minutes: Number(data.minutes),
       difficulty: difficulty,
-      days: modifiedDays,
+      days: data.days as Day[],
     });
 
     // リセット処理
@@ -107,8 +105,16 @@ export const NewPresenter = () => {
             <div className="my-2">
               <p className="block my-2">実施頻度</p>
               <div className="flex mt-4 gap-1">
-                {DAYS.map((v, i) => {
-                  return <NewDayOfTheWeek key={i} day={v} value={i + 1} register={register} watch={watch} />;
+                {DAYS.map((day, i) => {
+                  return (
+                    <NewDayOfTheWeek
+                      key={i}
+                      day={convertEnToJPWeekday(day)}
+                      value={day}
+                      register={register}
+                      watch={watch}
+                    />
+                  );
                 })}
               </div>
               {errors.days && <FormErrorMsg msg={errors.days.message ?? ""} />}


### PR DESCRIPTION
## 関連 issue
- #55 

## 説明
- 曜日を完全にstring[]で持つようにしてみる
- Numberにするなどというくどいことはなくなりました

## 動作確認手順
- `<NewDayOfTheWeek>`で`console.log(days)`してみて曜日順が担保されていることを確認してみてください～

## 相談したいこと

## 確認して欲しいこと

## 参考 URL 等
