### PR TITLE
要約APIのデータのフェッチと流し込み

### DIFF
--- a/src/api/weeklyReport/factory.ts
+++ b/src/api/weeklyReport/factory.ts
@@ -14,7 +14,7 @@ export const createFactory = () => {
       return weeklyReports;
     },
     getWeeklyReportSummary: async (getSummaryParams: GetSummaryParams) => {
-      const response = await repository.getSummary(getSummaryParams);
+      const response = await repository.summarize(getSummaryParams);
       return response.summary;
     },
   };

--- a/src/api/weeklyReport/factory.ts
+++ b/src/api/weeklyReport/factory.ts
@@ -12,5 +12,9 @@ export const createFactory = () => {
       });
       return weeklyReports;
     },
+    getWeeklyReportSummary: async () => {
+      const response = await repository.getSummary();
+      return response.summary;
+    },
   };
 };

--- a/src/api/weeklyReport/factory.ts
+++ b/src/api/weeklyReport/factory.ts
@@ -1,5 +1,6 @@
 import { WeeklyReport, toWeeklyReport } from "./model";
 import { weeklyReportsRepository } from "./repository";
+import { GetSummaryParams } from "./types";
 
 export const createFactory = () => {
   const repository = weeklyReportsRepository;
@@ -12,8 +13,8 @@ export const createFactory = () => {
       });
       return weeklyReports;
     },
-    getWeeklyReportSummary: async () => {
-      const response = await repository.getSummary();
+    getWeeklyReportSummary: async (getSummaryParams: GetSummaryParams) => {
+      const response = await repository.getSummary(getSummaryParams);
       return response.summary;
     },
   };

--- a/src/api/weeklyReport/repository.ts
+++ b/src/api/weeklyReport/repository.ts
@@ -1,9 +1,9 @@
 import { apiClient } from "../../pkg/api/client/apiClient";
-import { ListResponse, SummaryResponse } from "./types";
+import { ListResponse, GetSummaryRequest, GetSummaryResponse } from "./types";
 
 export interface WeeklyReportsRepository {
   list: () => Promise<ListResponse>;
-  getSummary: () => Promise<SummaryResponse>;
+  getSummary: (params: GetSummaryRequest) => Promise<GetSummaryResponse>;
 }
 
 const list: WeeklyReportsRepository["list"] = async () => {
@@ -11,8 +11,8 @@ const list: WeeklyReportsRepository["list"] = async () => {
   return response;
 };
 
-const getSummary: WeeklyReportsRepository["getSummary"] = async () => {
-  const response = await apiClient.get("/weekly-reports/summarize");
+const getSummary: WeeklyReportsRepository["getSummary"] = async (params: GetSummaryRequest) => {
+  const response = await apiClient.get(`/weekly-reports/summarize/${params.weeklyReportIndex}`);
   return response;
 };
 

--- a/src/api/weeklyReport/repository.ts
+++ b/src/api/weeklyReport/repository.ts
@@ -1,8 +1,9 @@
 import { apiClient } from "../../pkg/api/client/apiClient";
-import { ListResponse } from "./types";
+import { ListResponse, SummaryResponse } from "./types";
 
 export interface WeeklyReportsRepository {
   list: () => Promise<ListResponse>;
+  getSummary: () => Promise<SummaryResponse>;
 }
 
 const list: WeeklyReportsRepository["list"] = async () => {
@@ -10,6 +11,12 @@ const list: WeeklyReportsRepository["list"] = async () => {
   return response;
 };
 
+const getSummary: WeeklyReportsRepository["getSummary"] = async () => {
+  const response = await apiClient.get("/weekly-reports/summarize");
+  return response;
+};
+
 export const weeklyReportsRepository: WeeklyReportsRepository = {
   list,
+  getSummary,
 };

--- a/src/api/weeklyReport/repository.ts
+++ b/src/api/weeklyReport/repository.ts
@@ -3,7 +3,7 @@ import { ListResponse, GetSummaryRequest, GetSummaryResponse } from "./types";
 
 export interface WeeklyReportsRepository {
   list: () => Promise<ListResponse>;
-  getSummary: (params: GetSummaryRequest) => Promise<GetSummaryResponse>;
+  summarize: (params: GetSummaryRequest) => Promise<GetSummaryResponse>;
 }
 
 const list: WeeklyReportsRepository["list"] = async () => {
@@ -11,12 +11,12 @@ const list: WeeklyReportsRepository["list"] = async () => {
   return response;
 };
 
-const getSummary: WeeklyReportsRepository["getSummary"] = async (params: GetSummaryRequest) => {
+const summarize: WeeklyReportsRepository["summarize"] = async (params: GetSummaryRequest) => {
   const response = await apiClient.get(`/weekly-reports/summarize/${params.weeklyReportIndex}`);
   return response;
 };
 
 export const weeklyReportsRepository: WeeklyReportsRepository = {
   list,
-  getSummary,
+  summarize,
 };

--- a/src/api/weeklyReport/types.ts
+++ b/src/api/weeklyReport/types.ts
@@ -12,7 +12,13 @@ export type ListResponse = {
     user_id: string;
   }[];
 };
-export type SummaryResponse = {
+export type GetSummaryParams = {
+  weeklyReportIndex: number;
+};
+export type GetSummaryRequest = {
+  weeklyReportIndex: number;
+};
+export type GetSummaryResponse = {
   status: string;
   summary: string;
 };

--- a/src/api/weeklyReport/types.ts
+++ b/src/api/weeklyReport/types.ts
@@ -12,3 +12,7 @@ export type ListResponse = {
     user_id: string;
   }[];
 };
+export type SummaryResponse = {
+  status: string;
+  summary: string;
+};

--- a/src/features/analytics/api/weeklyReport/hooks/useQueryWeeklyReport.ts
+++ b/src/features/analytics/api/weeklyReport/hooks/useQueryWeeklyReport.ts
@@ -6,10 +6,22 @@ import { createFactory } from "../../../../../api/weeklyReport/factory";
 export const useQueryListWeeklyReports = () => {
   const weeklyReportFactory = createFactory();
   return useQuery<WeeklyReport[], FetchError>({
-    queryKey: ["weeklyReports"],
+    queryKey: ["listWeeklyReports"],
     queryFn: async () => {
       const weeklyReports = await weeklyReportFactory.listWeeklyReports();
       return weeklyReports;
+    },
+    staleTime: Infinity,
+  });
+};
+
+export const useQueryWeeklyReportSummary = () => {
+  const weeklyReportFactory = createFactory();
+  return useQuery<string, FetchError>({
+    queryKey: ["weeklyReportSummary"],
+    queryFn: async () => {
+      const summary = await weeklyReportFactory.getWeeklyReportSummary();
+      return summary;
     },
     staleTime: Infinity,
   });

--- a/src/features/analytics/api/weeklyReport/hooks/useQueryWeeklyReport.ts
+++ b/src/features/analytics/api/weeklyReport/hooks/useQueryWeeklyReport.ts
@@ -3,7 +3,7 @@ import { FetchError } from "../../../../../pkg/api/util/fetchError";
 import { WeeklyReport } from "../../../../../api/weeklyReport/model";
 import { createFactory } from "../../../../../api/weeklyReport/factory";
 
-export const useQueryWeeklyReports = () => {
+export const useQueryListWeeklyReports = () => {
   const weeklyReportFactory = createFactory();
   return useQuery<WeeklyReport[], FetchError>({
     queryKey: ["weeklyReports"],

--- a/src/features/analytics/api/weeklyReport/hooks/useQueryWeeklyReport.ts
+++ b/src/features/analytics/api/weeklyReport/hooks/useQueryWeeklyReport.ts
@@ -3,7 +3,7 @@ import { FetchError } from "../../../../../pkg/api/util/fetchError";
 import { WeeklyReport } from "../../../../../api/weeklyReport/model";
 import { createFactory } from "../../../../../api/weeklyReport/factory";
 
-export const useQueryListWeeklyReports = () => {
+export const useQueryWeeklyReports = () => {
   const weeklyReportFactory = createFactory();
   return useQuery<WeeklyReport[], FetchError>({
     queryKey: ["listWeeklyReports"],

--- a/src/features/analytics/api/weeklyReport/hooks/useQueryWeeklyReport.ts
+++ b/src/features/analytics/api/weeklyReport/hooks/useQueryWeeklyReport.ts
@@ -15,12 +15,12 @@ export const useQueryListWeeklyReports = () => {
   });
 };
 
-export const useQueryWeeklyReportSummary = () => {
+export const useQueryWeeklyReportSummary = (weeklyReportIndex: number) => {
   const weeklyReportFactory = createFactory();
   return useQuery<string, FetchError>({
     queryKey: ["weeklyReportSummary"],
     queryFn: async () => {
-      const summary = await weeklyReportFactory.getWeeklyReportSummary();
+      const summary = await weeklyReportFactory.getWeeklyReportSummary({ weeklyReportIndex: weeklyReportIndex });
       return summary;
     },
     staleTime: Infinity,

--- a/src/features/analytics/components/AnalyticsPresenter.tsx
+++ b/src/features/analytics/components/AnalyticsPresenter.tsx
@@ -80,7 +80,7 @@ export const AnalyticsPresenter = () => {
         </div>
       ) : (
         <div className="w-full gap-4 flex flex-col items-center mx-auto mt-24 text-xl">
-          <div>週刊レポートがまだありません</div>
+          <div>週間レポートがまだありません</div>
           <div>日曜日が終わるとレポートが作成されます</div>
         </div>
       )}

--- a/src/features/analytics/components/AnalyticsPresenter.tsx
+++ b/src/features/analytics/components/AnalyticsPresenter.tsx
@@ -2,13 +2,13 @@ import { useState } from "react";
 import { AnalyticsLeftButton, AnalyticsRightButton } from "./AnalyticsArrowButton";
 import { AnalyticsBarChart } from "./AnalyticsBarChart";
 import { AnalyticsCard } from "./AnalyticsCard";
-import { useQueryWeeklyReports } from "../api/weeklyReport/hooks/useQueryWeeklyReport";
+import { useQueryListWeeklyReports } from "../api/weeklyReport/hooks/useQueryWeeklyReport";
 
 export const AnalyticsPresenter = () => {
   const [currentIndex, setCurrentIndex] = useState<number>(0);
   // const [graphDataIndex, setGraphDataIndex] = useState<number>(0);
 
-  const { data: dataItem, isLoading } = useQueryWeeklyReports();
+  const { data: dataItem, isLoading } = useQueryListWeeklyReports();
 
   // 日付の配列の作成
   const dateArray = dataItem?.length

--- a/src/features/analytics/components/AnalyticsPresenter.tsx
+++ b/src/features/analytics/components/AnalyticsPresenter.tsx
@@ -1,15 +1,28 @@
-import { useState } from "react";
+import { useEffect, useState } from "react";
 import { AnalyticsLeftButton, AnalyticsRightButton } from "./AnalyticsArrowButton";
 import { AnalyticsBarChart } from "./AnalyticsBarChart";
 import { AnalyticsCard } from "./AnalyticsCard";
-import { useQueryListWeeklyReports, useQueryWeeklyReportSummary } from "../api/weeklyReport/hooks/useQueryWeeklyReport";
+import { useQueryListWeeklyReports } from "../api/weeklyReport/hooks/useQueryWeeklyReport";
+import { apiClient } from "../../../pkg/api/client/apiClient";
 
 export const AnalyticsPresenter = () => {
   const [currentIndex, setCurrentIndex] = useState<number>(0);
   // const [graphDataIndex, setGraphDataIndex] = useState<number>(0);
 
-  const { data: dataItem, isLoading } = useQueryListWeeklyReports();
-  const { data: summary, isLoading: isLoadingSummary } = useQueryWeeklyReportSummary();
+  const { data: dataItem, isLoading: isLoadingList } = useQueryListWeeklyReports();
+  const [summary, setSummary] = useState<string>();
+
+  useEffect(() => {
+    if (currentIndex !== (dataItem?.length ?? 0) - 1) {
+      apiClient.get(`/weekly-reports/summarize/${currentIndex}`).then((res): void => {
+        setSummary(res.summary);
+        return;
+      });
+    } else {
+      setSummary("来週以降、結果に応じてアドバイスが表示されます！");
+    }
+  }, [currentIndex]);
+
   // 日付の配列の作成
   const dateArray = dataItem?.length
     ? dataItem.map((item) => ({
@@ -26,10 +39,9 @@ export const AnalyticsPresenter = () => {
     setCurrentIndex((prevIndex) => (prevIndex === (dataItem ? dataItem.length - 1 : 0) ? 0 : prevIndex + 1));
     // setGraphDataIndex((prevIndex) => (prevIndex === (graphData ? graphData.length - 1 : 0) ? 0 : prevIndex + 1));
   };
-
   return (
     <>
-      {isLoading ? (
+      {isLoadingList ? (
         <div>Loading...</div>
       ) : dataItem?.length ? (
         <div className="flex flex-col items-center w-fit mx-auto">

--- a/src/features/analytics/components/AnalyticsPresenter.tsx
+++ b/src/features/analytics/components/AnalyticsPresenter.tsx
@@ -2,14 +2,14 @@ import { useState } from "react";
 import { AnalyticsLeftButton, AnalyticsRightButton } from "./AnalyticsArrowButton";
 import { AnalyticsBarChart } from "./AnalyticsBarChart";
 import { AnalyticsCard } from "./AnalyticsCard";
-import { useQueryListWeeklyReports } from "../api/weeklyReport/hooks/useQueryWeeklyReport";
+import { useQueryListWeeklyReports, useQueryWeeklyReportSummary } from "../api/weeklyReport/hooks/useQueryWeeklyReport";
 
 export const AnalyticsPresenter = () => {
   const [currentIndex, setCurrentIndex] = useState<number>(0);
   // const [graphDataIndex, setGraphDataIndex] = useState<number>(0);
 
   const { data: dataItem, isLoading } = useQueryListWeeklyReports();
-
+  const { data: summary, isLoading: isLoadingSummary } = useQueryWeeklyReportSummary();
   // 日付の配列の作成
   const dateArray = dataItem?.length
     ? dataItem.map((item) => ({
@@ -72,6 +72,11 @@ export const AnalyticsPresenter = () => {
             <h1 className="text-lg mt-8 font-bold">曜日別クエスト達成状況</h1>
           </div>
           <AnalyticsBarChart data={dataItem[currentIndex].completed_quests_each_day} />
+          {summary && (
+            <div className="mt-3 text-lg border-2 max-w-sm w-full px-3 py-4 bg-white rounded-lg shadow font-bold">
+              {summary}
+            </div>
+          )}
         </div>
       ) : (
         <div className="w-full gap-4 flex flex-col items-center mx-auto mt-24 text-xl">

--- a/src/features/analytics/components/AnalyticsPresenter.tsx
+++ b/src/features/analytics/components/AnalyticsPresenter.tsx
@@ -2,25 +2,20 @@ import { useEffect, useState } from "react";
 import { AnalyticsLeftButton, AnalyticsRightButton } from "./AnalyticsArrowButton";
 import { AnalyticsBarChart } from "./AnalyticsBarChart";
 import { AnalyticsCard } from "./AnalyticsCard";
-import { useQueryListWeeklyReports } from "../api/weeklyReport/hooks/useQueryWeeklyReport";
-import { apiClient } from "../../../pkg/api/client/apiClient";
+import { useQueryWeeklyReports, useQueryWeeklyReportSummary } from "../api/weeklyReport/hooks/useQueryWeeklyReport";
 
 export const AnalyticsPresenter = () => {
   const [currentIndex, setCurrentIndex] = useState<number>(0);
   // const [graphDataIndex, setGraphDataIndex] = useState<number>(0);
 
-  const { data: dataItem, isLoading: isLoadingList } = useQueryListWeeklyReports();
-  const [summary, setSummary] = useState<string>();
-
+  const { data: dataItem, isLoading: isLoadingList } = useQueryWeeklyReports();
+  const {
+    data: summaryData,
+    refetch: refetchSummary,
+    isFetching: isFetchingSummary,
+  } = useQueryWeeklyReportSummary(currentIndex);
   useEffect(() => {
-    if (currentIndex !== (dataItem?.length ?? 0) - 1) {
-      apiClient.get(`/weekly-reports/summarize/${currentIndex}`).then((res): void => {
-        setSummary(res.summary);
-        return;
-      });
-    } else {
-      setSummary("来週以降、結果に応じてアドバイスが表示されます！");
-    }
+    refetchSummary();
   }, [currentIndex]);
 
   // 日付の配列の作成
@@ -84,10 +79,14 @@ export const AnalyticsPresenter = () => {
             <h1 className="text-lg mt-8 font-bold">曜日別クエスト達成状況</h1>
           </div>
           <AnalyticsBarChart data={dataItem[currentIndex].completed_quests_each_day} />
-          {summary && (
-            <div className="mt-3 text-lg border-2 max-w-sm w-full px-3 py-4 bg-white rounded-lg shadow font-bold">
-              {summary}
-            </div>
+          {isFetchingSummary ? (
+            <div>Generating summary...</div>
+          ) : (
+            summaryData && (
+              <div className="mt-3 text-lg border-2 max-w-sm w-full px-3 py-4 bg-white rounded-lg shadow font-bold">
+                {summaryData}
+              </div>
+            )
           )}
         </div>
       ) : (


### PR DESCRIPTION
## 関連 issue

## 説明
要約APIからデータのフェッチと流し込みを実装しました
## 動作確認手順
- バックエンドを`fix/summarize-api`ブランチに切り替えてください
- `npx prisma db seed`を行ってデータを作成してください。
- `email: test@gmail.com pass: hjk4m3nj`でログインし、統計ページを確認してください。
## 相談したいこと

## 確認して欲しいこと

## 参考 URL 等
