### PR TITLE
クエスト検索画面のボタンバグ修正、背景色を画面全体に表示

### DIFF
--- a/index.css
+++ b/index.css
@@ -1,0 +1,4 @@
+html,
+body {
+  height: 100%;
+}

--- a/src/features/common/components/layouts/ContentLayout.tsx
+++ b/src/features/common/components/layouts/ContentLayout.tsx
@@ -5,5 +5,5 @@ type Props = {
 };
 
 export const ContentLayout: FC<Props> = ({ children }) => {
-  return <div className="px-6 pb-28 pt-24 bg-rhyth-bg-dark-gray">{children}</div>;
+  return <div className="px-6 pb-28 pt-24 bg-rhyth-bg-dark-gray min-h-screen">{children}</div>;
 };

--- a/src/features/common/components/layouts/ContentLayout.tsx
+++ b/src/features/common/components/layouts/ContentLayout.tsx
@@ -5,5 +5,5 @@ type Props = {
 };
 
 export const ContentLayout: FC<Props> = ({ children }) => {
-  return <div className="px-6 pb-28 pt-20 bg-rhyth-bg-dark-gray">{children}</div>;
+  return <div className="px-6 pb-28 pt-24 bg-rhyth-bg-dark-gray">{children}</div>;
 };

--- a/src/features/manage/components/ManageDayOfTheWeekCheckBox.tsx
+++ b/src/features/manage/components/ManageDayOfTheWeekCheckBox.tsx
@@ -1,11 +1,11 @@
 import { ChangeEvent, FC } from "react";
-import { convertJPToENWeekday } from "../common/funcs";
 import { Day } from "../../../api/quest/types";
+import { convertEnToJPWeekday } from "../common/funcs";
 
 type Props = {
   handleDay: (day: Day | "") => void;
   day: Day | "";
-  dayOfTheWeek: string;
+  dayOfTheWeek: Day;
   index: number;
 };
 
@@ -15,17 +15,17 @@ export const ManageDayOfTheWeekCheckBox: FC<Props> = ({ handleDay, day, dayOfThe
       <input
         type="checkbox"
         className="hidden peer"
-        value={convertJPToENWeekday(dayOfTheWeek)}
+        value={dayOfTheWeek}
         id={`${index}`}
         onChange={(e: ChangeEvent<HTMLInputElement>) => handleDay(e.target.value as Day | "")}
       />
       <label
         htmlFor={`${index}`}
         className={`px-2 py-1 rounded border-2 cursor-pointer ${
-          day === convertJPToENWeekday(dayOfTheWeek) ? "bg-blue-400 text-white" : "bg-white text-black"
+          day === dayOfTheWeek ? "bg-blue-400 text-white" : "bg-white text-black"
         }`}
       >
-        {dayOfTheWeek}
+        {convertEnToJPWeekday(dayOfTheWeek)}
       </label>
     </div>
   );


### PR DESCRIPTION
## 関連 issue

## 説明

## 動作確認手順
クエスト検索ボタンが正しく使えてるか、背景色が画面全体に出ているか見てください
## 相談したいこと

## 確認して欲しいこと

## 参考 URL 等
