### PR TITLE
Fix/weekly report arrow button and etc

### DIFF
--- a/src/features/analytics/components/AnalyticsPresenter.tsx
+++ b/src/features/analytics/components/AnalyticsPresenter.tsx
@@ -3,6 +3,7 @@ import { AnalyticsLeftButton, AnalyticsRightButton } from "./AnalyticsArrowButto
 import { AnalyticsBarChart } from "./AnalyticsBarChart";
 import { AnalyticsCard } from "./AnalyticsCard";
 import { useQueryWeeklyReports, useQueryWeeklyReportSummary } from "../api/weeklyReport/hooks/useQueryWeeklyReport";
+import { Loading } from "../../common/components/Loading";
 
 export const AnalyticsPresenter = () => {
   const [currentIndex, setCurrentIndex] = useState<number>(0);
@@ -37,17 +38,19 @@ export const AnalyticsPresenter = () => {
   return (
     <>
       {isLoadingList ? (
-        <div>Loading...</div>
+        <div className="h-screen">
+          <Loading />
+        </div>
       ) : dataItem?.length ? (
         <div className="flex flex-col items-center w-fit mx-auto">
-          <div className="flex w-full justify-between items-center">
-            <AnalyticsLeftButton onClickFn={handleClickPrev} />
+          <div className="flex w-full justify-center items-center">
+            {currentIndex !== dataItem.length - 1 && <AnalyticsLeftButton onClickFn={handleClickPrev} />}
             <div className="flex">
-              <p className="text-xl mx-2 block text-center font-bold">
+              <p className="text-xl px-10 mx-2 block text-center font-bold">
                 {dateArray[currentIndex].start} ～ {dateArray[currentIndex].end}の週
               </p>
             </div>
-            <AnalyticsRightButton onClickFn={handleClickNext} />
+            {currentIndex !== 0 && <AnalyticsRightButton onClickFn={handleClickNext} />}
           </div>
           <div className="grid grid-cols-2 gap-6 mt-6">
             <AnalyticsCard
@@ -80,7 +83,9 @@ export const AnalyticsPresenter = () => {
           </div>
           <AnalyticsBarChart data={dataItem[currentIndex].completed_quests_each_day} />
           {isFetchingSummary ? (
-            <div>Generating summary...</div>
+            <div className="p-10">
+              <Loading />
+            </div>
           ) : (
             summaryData && (
               <div className="mt-3 text-lg border-2 max-w-sm w-full px-3 py-4 bg-white rounded-lg shadow font-bold">

--- a/src/features/common/components/Loading.tsx
+++ b/src/features/common/components/Loading.tsx
@@ -1,11 +1,11 @@
 export const Loading = () => {
   return (
-    <div className="h-screen flex items-center justify-center">
-      <div role="status">
+    <div className="flex items-center justify-center">
+      <div role="status" className="flex">
         <svg
           aria-hidden="true"
-          className="inline w-16 h-16 text-rhyth-gray animate-spin fill-rhyth-blue"
-          viewBox="0 0 100 101"
+          className="inline w-8 h-8 text-rhyth-gray animate-spin fill-rhyth-blue"
+          viewBox="0 0 100 100"
           fill="none"
           xmlns="http://www.w3.org/2000/svg"
         >

--- a/src/features/manage/components/ManagePresenter.tsx
+++ b/src/features/manage/components/ManagePresenter.tsx
@@ -40,7 +40,9 @@ export const ManagePresenter = () => {
     <div className="w-full">
       <ManageQuestSearchModalButton onClickFn={openQuestSearchModal} />
       {isLoading ? (
-        <Loading />
+        <div className="h-screen">
+          <Loading />
+        </div>
       ) : filterActivation ? (
         filteredData?.length ? (
           <ul className="mt-4 flex flex-col items-center gap-6">

--- a/src/features/manage/edit/components/EditPresenter.tsx
+++ b/src/features/manage/edit/components/EditPresenter.tsx
@@ -85,7 +85,9 @@ export const EditPresenter: FC<Props> = (props) => {
       </div>
       <h1 className="text-2xl font-bold mt-8">クエスト編集</h1>
       {isLoading ? (
-        <Loading />
+        <div className="h-screen">
+          <Loading />
+        </div>
       ) : (
         <form onSubmit={handleSubmit(onSubmit)}>
           <div className="mt-6 flex flex-col gap-4">

--- a/src/features/quests/components/QuestsPresenter.tsx
+++ b/src/features/quests/components/QuestsPresenter.tsx
@@ -44,7 +44,15 @@ export const QuestsPresenter = () => {
         {formatDateJP(now())}
         {`(${getToday()})`}のクエスト
       </h1>
-      {isLoading ? <Loading /> : currentQuest ? <QuestBoard currentQuest={currentQuest} /> : <QuestBoardNoData />}
+      {isLoading ? (
+        <div className="h-screen">
+          <Loading />
+        </div>
+      ) : currentQuest ? (
+        <QuestBoard currentQuest={currentQuest} />
+      ) : (
+        <QuestBoardNoData />
+      )}
       <div className={`flex flex-col gap-2 w-full p-3 mt-4 bg-gray-100 rounded-md `}>
         <div className="flex items-center gap-2">
           <button

--- a/src/routes/quests/index.lazy.tsx
+++ b/src/routes/quests/index.lazy.tsx
@@ -3,8 +3,6 @@ import { Menu } from "../../features/common/components/Menu";
 import { Header } from "../../features/common/components/header/Header";
 import { ContentLayout } from "../../features/common/components/layouts/ContentLayout";
 import { QuestsPresenter } from "../../features/quests/components/QuestsPresenter";
-import { Suspense } from "react";
-import { Loading } from "../../features/common/components/Loading";
 
 export const Route = createLazyFileRoute("/quests/")({
   component: () => <Quests />,
@@ -15,9 +13,7 @@ const Quests = () => {
     <>
       <Header />
       <ContentLayout>
-        <Suspense fallback={<Loading />}>
-          <QuestsPresenter />
-        </Suspense>
+        <QuestsPresenter />
       </ContentLayout>
       <Menu />
     </>

--- a/tailwind.config.js
+++ b/tailwind.config.js
@@ -6,7 +6,7 @@ export default {
     extend: {
       fontFamily: {
         "noto-sans-jp": ["Noto Sans JP", "cursive"],
-        "cp-font": ["CP Font", "Append CP Font"]
+        "cp-font": ["CP Font", "Append CP Font"],
       },
       colors: {
         'rhyth-light-blue': '#1EA1FF',


### PR DESCRIPTION
## 関連 issue

## 説明
- 統計ページにおいて、端のレポートにおいて△ボタンを非表示にするように変えました
- Loading コンポーネントのクラスネームから `h-screen`を除きました
## 動作確認手順

## 相談したいこと

## 確認して欲しいこと

## 参考 URL 等
