### PR TITLE
fix:モーダル外で閉じられるように修正

### DIFF
--- a/src/features/common/components/ConfirmModal.tsx
+++ b/src/features/common/components/ConfirmModal.tsx
@@ -16,10 +16,11 @@ export const ConfirmModal: FC<Props> = (props) => {
   };
   const { text, confirmBtnText, cancelBtnText, btnColor, actionFn, closeModal } = props;
   return (
-    <div className="fixed top-0 left-0 w-full h-full bg-gray-500 bg-opacity-50 z-50">
+    <>
+      <div className="fixed top-0 left-0 w-full h-full bg-gray-500 bg-opacity-50 z-50" onClick={closeModal} />
       <div
         aria-hidden="true"
-        className="overflow-y-auto overflow-x-hidden flex justify-center items-center z-50 w-full md:inset-0 h-[calc(100%-1rem)] max-h-full"
+        className="overflow-y-auto overflow-x-hidden flex justify-center items-center z-[100] max-h-full fixed top-1/2 left-1/2 transform -translate-x-1/2 -translate-y-1/2 w-full"
       >
         <div className="relative p-4 w-full max-w-md max-h-full">
           {/* <!-- Modal content --> */}
@@ -70,6 +71,6 @@ export const ConfirmModal: FC<Props> = (props) => {
           </div>
         </div>
       </div>
-    </div>
+    </>
   );
 };

--- a/src/features/manage/components/ManageQuestSearchModal,.tsx
+++ b/src/features/manage/components/ManageQuestSearchModal,.tsx
@@ -1,8 +1,8 @@
 import { FC, useState } from "react";
+import { Day, Difficulty } from "../../../api/quest/types";
+import { DAYS, DIFFICULTIES } from "../common/constant/constant";
 import { ManageDayOfTheWeekCheckBox } from "./ManageDayOfTheWeekCheckBox";
 import { ManageDifficultyCheckBox } from "./ManageDifficultyCheckBox";
-import { DAYS, DIFFICULTIES } from "../common/constant/constant";
-import { Day, Difficulty } from "../../../api/quest/types";
 
 type Props = {
   onClickFn: () => void;
@@ -42,10 +42,11 @@ export const ManageQuestSearchModal: FC<Props> = ({
   };
 
   return (
-    <div className="fixed top-0 left-0 w-full h-full bg-gray-500 bg-opacity-50 z-50">
+    <>
+      <div className="fixed top-0 left-0 w-full h-full bg-gray-500 bg-opacity-50 z-50" onClick={onClickFn} />
       <div
         aria-hidden="true"
-        className="overflow-y-auto overflow-x-hidden flex justify-center items-center z-50 w-full md:inset-0 h-[calc(100%-1rem)] max-h-full"
+        className="overflow-y-auto overflow-x-hidden flex justify-center items-center z-[100] max-h-full fixed top-1/2 left-1/2 transform -translate-x-1/2 -translate-y-1/2 w-full"
       >
         <div className="relative p-4 w-full max-w-md max-h-full">
           {/* <!-- Modal content --> */}
@@ -165,6 +166,6 @@ export const ManageQuestSearchModal: FC<Props> = ({
           </div>
         </div>
       </div>
-    </div>
+    </>
   );
 };

--- a/src/features/profile/components/ProfileLogoutModal.tsx
+++ b/src/features/profile/components/ProfileLogoutModal.tsx
@@ -11,10 +11,11 @@ export const ProfileLogoutModal: FC<Props> = ({ onClickFn }) => {
     await logoutMutation.mutateAsync();
   };
   return (
-    <div className="fixed top-0 left-0 w-full h-full bg-gray-500 bg-opacity-50 z-50">
+    <>
+      <div className="fixed top-0 left-0 w-full h-full bg-gray-500 bg-opacity-50 z-50" onClick={onClickFn} />
       <div
         aria-hidden="true"
-        className="overflow-y-auto overflow-x-hidden flex justify-center items-center z-50 w-full md:inset-0 h-[calc(100%-1rem)] max-h-full"
+        className="overflow-y-auto overflow-x-hidden flex justify-center items-center z-[100] max-h-full fixed top-1/2 left-1/2 transform -translate-x-1/2 -translate-y-1/2"
       >
         <div className="relative p-4 w-full max-w-md max-h-full">
           {/* <!-- Modal content --> */}
@@ -57,6 +58,6 @@ export const ProfileLogoutModal: FC<Props> = ({ onClickFn }) => {
           </div>
         </div>
       </div>
-    </div>
+    </>
   );
 };

--- a/src/features/profile/components/ProfileLogoutModal.tsx
+++ b/src/features/profile/components/ProfileLogoutModal.tsx
@@ -15,7 +15,7 @@ export const ProfileLogoutModal: FC<Props> = ({ onClickFn }) => {
       <div className="fixed top-0 left-0 w-full h-full bg-gray-500 bg-opacity-50 z-50" onClick={onClickFn} />
       <div
         aria-hidden="true"
-        className="overflow-y-auto overflow-x-hidden flex justify-center items-center z-[100] max-h-full fixed top-1/2 left-1/2 transform -translate-x-1/2 -translate-y-1/2"
+        className="overflow-y-auto overflow-x-hidden flex justify-center items-center z-[100] max-h-full fixed top-1/2 left-1/2 transform -translate-x-1/2 -translate-y-1/2 w-full"
       >
         <div className="relative p-4 w-full max-w-md max-h-full">
           {/* <!-- Modal content --> */}

--- a/src/features/profile/components/ProfileUserSettingModal.tsx
+++ b/src/features/profile/components/ProfileUserSettingModal.tsx
@@ -1,9 +1,9 @@
-import { useForm } from "react-hook-form";
-import { TUserEditValidationSchema, userEditValidationSchema } from "../libs/validation";
 import { zodResolver } from "@hookform/resolvers/zod";
 import { FC } from "react";
-import { useMutateUser } from "../api/user/hooks/useMutateUser";
+import { useForm } from "react-hook-form";
 import { FormErrorMsg } from "../../common/components/utils/FormErrorMsg";
+import { useMutateUser } from "../api/user/hooks/useMutateUser";
+import { TUserEditValidationSchema, userEditValidationSchema } from "../libs/validation";
 
 type Props = {
   username: string;
@@ -31,10 +31,11 @@ export const ProfileUserSettingsModal: FC<Props> = ({ username, onClickFn }) => 
   };
 
   return (
-    <div className="fixed top-0 left-0 w-full h-full bg-gray-500 bg-opacity-50 z-50">
+    <>
+      <div className="fixed top-0 left-0 w-full h-full bg-gray-500 bg-opacity-50 z-50" onClick={onClickFn} />
       <div
         aria-hidden="true"
-        className="overflow-y-auto overflow-x-hidden flex justify-center items-center z-50 w-full md:inset-0 h-[calc(100%-1rem)] max-h-full"
+        className="overflow-y-auto overflow-x-hidden flex justify-center items-center z-[100] max-h-full fixed top-1/2 left-1/2 transform -translate-x-1/2 -translate-y-1/2 w-full"
       >
         <div className="relative p-4 w-full max-w-md max-h-full">
           {/* <!-- Modal content --> */}
@@ -92,6 +93,6 @@ export const ProfileUserSettingsModal: FC<Props> = ({ username, onClickFn }) => 
           </div>
         </div>
       </div>
-    </div>
+    </>
   );
 };


### PR DESCRIPTION
## 関連 issue

## 説明
モーダル外をクリックするとモーダルが閉じます。

## 動作確認手順
3種のモーダルを開いてください
ログアウト、プロフィール編集、クエスト検索

## 相談したいこと
w-fullを指定するとモーダルの横をクリックしても閉じません。
仕様ということにして割り切っていますが、解決策があったら教えてください。

## 確認して欲しいこと

## 参考 URL 等
