### PR TITLE
「ひとこと」のレイアウトが崩れないよう修正

### DIFF
--- a/src/features/manage/components/ManageQuestCard.tsx
+++ b/src/features/manage/components/ManageQuestCard.tsx
@@ -1,11 +1,11 @@
 import { useNavigate } from "@tanstack/react-router";
-import { ManageProgressBar } from "./ManageProgressBar";
 import { FC } from "react";
+import { Day, Difficulty } from "../../../api/quest/types";
 import { formatDateTimeOnlyTime } from "../../../pkg/util/dayjs";
 import { ClockIcon } from "../../common/components/icons/ClockIcon";
 import { calcExp } from "../../common/funcs/calcExp";
 import { convertEnToJPWeekday } from "../common/funcs";
-import { Day, Difficulty } from "../../../api/quest/types";
+import { ManageProgressBar } from "./ManageProgressBar";
 
 const convertENToJPWeekdayString = (weekDays: Day[]) => {
   const result = weekDays.map((day) => convertEnToJPWeekday(day)).join("・");
@@ -58,9 +58,9 @@ export const ManageQuestCard: FC<Props> = (props) => {
           </button>
         </div>
         <hr className="h-1.5 bg-rhyth-blue" />
-        <div className="flex items-center gap-2 text-sm mt-2">
+        <div className="flex items-start gap-2 text-sm mt-2">
           <div className="font-cp-font text-white bg-rhyth-gray py-1 px-3 rounded-full tracking-wider">
-            <p>ひとこと</p>
+            <p className="text-center whitespace-nowrap">ひとこと</p>
           </div>
           <h3 className="font-bold text-rhyth-dark-blue">{description}</h3>
         </div>

--- a/src/features/quests/components/QuestBoard.tsx
+++ b/src/features/quests/components/QuestBoard.tsx
@@ -84,9 +84,9 @@ export const QuestBoard: FC<Props> = (props) => {
       <div className="flex flex-col gap-1 px-3">
         <h1 className="font-bold text-lg text-rhyth-dark-blue mb-2">{currentQuest.title}</h1>
         <hr className="h-1.5 bg-rhyth-blue" />
-        <div className="flex items-center gap-2 text-sm mt-2">
+        <div className="flex items-start gap-2 text-sm mt-2">
           <div className="font-cp-font text-white bg-rhyth-gray py-1 px-3 rounded-full tracking-wider">
-            <p>ひとこと</p>
+            <p className="text-center whitespace-nowrap">ひとこと</p>
           </div>
           <h3 className="font-bold text-rhyth-dark-blue">{currentQuest.description}</h3>
         </div>


### PR DESCRIPTION
## 関連 issue

## 説明
ひとことに長文を入力した際にレイアウトが崩れないよう修正
ひとことを20字に制限しました

## 動作確認手順

## 相談したいこと

## 確認して欲しいこと

## 参考 URL 等
