### PR TITLE
画像切り取り機能の実装

### DIFF
--- a/src/features/profile/settings/components/ImageCropModal.tsx
+++ b/src/features/profile/settings/components/ImageCropModal.tsx
@@ -11,8 +11,8 @@ type Props = {
 };
 
 export const ImageCropModal: FC<Props> = ({ imageUrl, closeModal }) => {
-  const imgRef = useRef(null);
-  const previewCanvasRef = useRef(null);
+  const imgRef = useRef<HTMLImageElement>(null);
+  const previewCanvasRef = useRef<HTMLCanvasElement>(null);
   const [crop, setCrop] = useState<Crop>({
     unit: "%",
     x: 25,
@@ -22,7 +22,7 @@ export const ImageCropModal: FC<Props> = ({ imageUrl, closeModal }) => {
   });
 
   const centerAspectCrop = (mediaWidth: number, mediaHeight: number, aspect: number) => {
-    const cropWidthInPercent = (150 / mediaHeight) * 100;
+    const cropWidthInPercent = (150 / mediaWidth) * 100;
     return centerCrop(
       makeAspectCrop(
         {
@@ -68,13 +68,23 @@ export const ImageCropModal: FC<Props> = ({ imageUrl, closeModal }) => {
               setCanvasPreview(
                 imgRef.current,
                 previewCanvasRef.current,
-                convertToPixelCrop(crop, imgRef.current.width, imgRef.current.height),
+                convertToPixelCrop(crop, imgRef.current!.width, imgRef.current!.height),
               );
             }}
           >
             画像を切り取る
           </button>
-          {crop && <canvas ref={previewCanvasRef} style={{ objectFit: "contain", width: 200, height: 200 }} />}
+          {crop ? <canvas ref={previewCanvasRef} style={{ objectFit: "contain", width: 200, height: 200 }} /> : null}
+          <button
+            type="submit"
+            onClick={() => {
+              const dataUrl = previewCanvasRef.current?.toDataURL();
+              console.log(dataUrl);
+            }}
+            className="border p-2 bg-gray-300"
+          >
+            送信
+          </button>
         </div>
       </div>
     </ModalBase>

--- a/src/features/profile/settings/components/ImageCropModal.tsx
+++ b/src/features/profile/settings/components/ImageCropModal.tsx
@@ -21,6 +21,8 @@ export const ImageCropModal: FC<Props> = ({ imageUrl, closeModal }) => {
     height: 50,
   });
 
+  const [isCropped, setIsCropped] = useState<boolean>(false);
+
   const centerAspectCrop = (mediaWidth: number, mediaHeight: number, aspect: number) => {
     const cropWidthInPercent = (150 / mediaWidth) * 100;
     return centerCrop(
@@ -48,23 +50,19 @@ export const ImageCropModal: FC<Props> = ({ imageUrl, closeModal }) => {
       <div className="order relative bg-white rounded-lg shadow">
         {/* <!-- Modal header --> */}
         <div className="flex items-center justify-between p-4 md:p-4 rounded-t border-b">
-          <h3 className="font-cp-font text-xl font-bold text-rhyth-dark-blue">あああ</h3>
+          <h3 className="font-cp-font text-xl font-bold text-rhyth-dark-blue">画像の切り取り</h3>
           <ModalHeaderCloseButton onClickClose={closeModal} />
         </div>
         {/* <!-- Modal body --> */}
-        <div className="p-4 md:p-4">
-          <ReactCrop
-            crop={crop}
-            keepSelection
-            onChange={(_, percentCrop) => setCrop(percentCrop)}
-            aspect={1}
-            className="bg-red-400"
-          >
+        <div className="grid gap-3 p-4 md:p-4">
+          <ReactCrop crop={crop} keepSelection onChange={(_, percentCrop) => setCrop(percentCrop)} aspect={1}>
             <img ref={imgRef} src={imageUrl} onLoad={onImageLoad} />
           </ReactCrop>
           <button
-            className="border p-2 bg-gray-300"
+            type="button"
+            className="w-full text-white bg-rhyth-gray hover:bg-hover-gray active:ring-4 focus:outline-none  font-medium rounded-lg text-sm px-5 py-2.5 text-center"
             onClick={() => {
+              setIsCropped(true);
               setCanvasPreview(
                 imgRef.current,
                 previewCanvasRef.current,
@@ -74,14 +72,26 @@ export const ImageCropModal: FC<Props> = ({ imageUrl, closeModal }) => {
           >
             画像を切り取る
           </button>
-          {crop ? <canvas ref={previewCanvasRef} style={{ objectFit: "contain", width: 200, height: 200 }} /> : null}
+          {crop ? (
+            <div className="flex items-center justify-center">
+              <canvas
+                ref={previewCanvasRef}
+                style={{
+                  objectFit: "contain",
+                  // クロップされてないときは display:none にしたいのにできない
+                  // display: isCropped ? "contents" : "none",
+                }}
+                className="w-full"
+              />
+            </div>
+          ) : null}
           <button
             type="submit"
             onClick={() => {
               const dataUrl = previewCanvasRef.current?.toDataURL();
               console.log(dataUrl);
             }}
-            className="border p-2 bg-gray-300"
+            className="w-full text-white bg-rhyth-light-blue hover:bg-rhyth-blue focus:ring-4 focus:outline-none focus:ring-blue-300 font-medium rounded-lg text-sm px-5 py-2.5 text-center"
           >
             送信
           </button>

--- a/src/features/profile/settings/components/ImageCropModal.tsx
+++ b/src/features/profile/settings/components/ImageCropModal.tsx
@@ -1,0 +1,82 @@
+import { FC, useRef, useState } from "react";
+import ReactCrop, { centerCrop, convertToPixelCrop, makeAspectCrop, type Crop } from "react-image-crop";
+import "react-image-crop/dist/ReactCrop.css";
+import { ModalBase } from "../../../common/components/modal/ModalBase";
+import { ModalHeaderCloseButton } from "../../../common/components/modal/ModalHeaderCloseButton";
+import { setCanvasPreview } from "./setCanvasPreview";
+
+type Props = {
+  closeModal: () => void;
+  imageUrl: string;
+};
+
+export const ImageCropModal: FC<Props> = ({ imageUrl, closeModal }) => {
+  const imgRef = useRef(null);
+  const previewCanvasRef = useRef(null);
+  const [crop, setCrop] = useState<Crop>({
+    unit: "%",
+    x: 25,
+    y: 25,
+    width: 50,
+    height: 50,
+  });
+
+  const centerAspectCrop = (mediaWidth: number, mediaHeight: number, aspect: number) => {
+    const cropWidthInPercent = (150 / mediaHeight) * 100;
+    return centerCrop(
+      makeAspectCrop(
+        {
+          unit: "%",
+          width: cropWidthInPercent,
+        },
+        aspect,
+        mediaWidth,
+        mediaHeight,
+      ),
+      mediaWidth,
+      mediaHeight,
+    );
+  };
+
+  const onImageLoad = (e: React.SyntheticEvent<HTMLImageElement>) => {
+    const { naturalWidth, naturalHeight } = e.currentTarget;
+    setCrop(centerAspectCrop(naturalWidth, naturalHeight, 1));
+  };
+
+  return (
+    <ModalBase onClickClose={closeModal}>
+      <div className="order relative bg-white rounded-lg shadow">
+        {/* <!-- Modal header --> */}
+        <div className="flex items-center justify-between p-4 md:p-4 rounded-t border-b">
+          <h3 className="font-cp-font text-xl font-bold text-rhyth-dark-blue">あああ</h3>
+          <ModalHeaderCloseButton onClickClose={closeModal} />
+        </div>
+        {/* <!-- Modal body --> */}
+        <div className="p-4 md:p-4">
+          <ReactCrop
+            crop={crop}
+            keepSelection
+            onChange={(_, percentCrop) => setCrop(percentCrop)}
+            aspect={1}
+            className="bg-red-400"
+          >
+            <img ref={imgRef} src={imageUrl} onLoad={onImageLoad} />
+          </ReactCrop>
+          <button
+            className="border p-2 bg-gray-300"
+            onClick={() => {
+              setCanvasPreview(
+                imgRef.current,
+                previewCanvasRef.current,
+                convertToPixelCrop(crop, imgRef.current.width, imgRef.current.height),
+              );
+            }}
+          >
+            画像を切り取る
+          </button>
+          {crop && <canvas ref={previewCanvasRef} style={{ objectFit: "contain", width: 200, height: 200 }} />}
+        </div>
+      </div>
+    </ModalBase>
+  );
+};

--- a/src/features/profile/settings/components/SettingsPresenter.tsx
+++ b/src/features/profile/settings/components/SettingsPresenter.tsx
@@ -1,22 +1,31 @@
-import { useNavigate } from "@tanstack/react-router";
-import { useRef, useState } from "react";
 import { zodResolver } from "@hookform/resolvers/zod";
+import { useNavigate } from "@tanstack/react-router";
+import { FC, useRef, useState } from "react";
 import { useForm } from "react-hook-form";
-import { SettingsInputImage } from "./SettingsInputImage";
-import { useQueryLoginUser } from "../../api/user/hooks/useQueryUser";
-import { useMutateUser } from "../../api/user/hooks/useMutateUser";
-import { TUserEditValidationSchema, userEditValidationSchema } from "../../libs/validation";
-import { useGetImageUrl } from "../hooks/useGetImageUrl";
-import { BadgesBackButton } from "../../badges/components/BadgesBackButton";
 import { ConfirmModal, FormErrorMsg } from "../../../common/components";
+import { useMutateUser } from "../../api/user/hooks/useMutateUser";
+import { useQueryLoginUser } from "../../api/user/hooks/useQueryUser";
+import { BadgesBackButton } from "../../badges/components/BadgesBackButton";
+import {
+  TUserEditValidationSchema,
+  userEditValidationSchema,
+} from "../../libs/validation";
+import { useGetImageUrl } from "../hooks/useGetImageUrl";
+import { ImageCropModal } from "./ImageCropModal";
+import { SettingsInputImage } from "./SettingsInputImage";
 
 const IMAGE_ID = "imageId";
 
-export const SettingsPresenter = () => {
+type Props = {
+  onClickFn: () => void;
+};
+
+export const SettingsPresenter: FC<Props> = ({ onClickFn }) => {
   const navigation = useNavigate();
 
   const { data: loginUser } = useQueryLoginUser();
   const { updateUserMutation } = useMutateUser();
+  const [openModal, setOpenModal] = useState(false);
 
   const {
     register,
@@ -45,7 +54,15 @@ export const SettingsPresenter = () => {
     }
   };
 
-  const [openModal, setOpenModal] = useState(false);
+  const [imageCropModalOpen, setImageCropModalOpen] = useState<boolean>(false);
+
+  const ShowImageCropModal = () => {
+    setImageCropModalOpen(true);
+  };
+
+  const closeImageCropModal = () => {
+    setImageCropModalOpen(false);
+  };
 
   return (
     <>
@@ -57,19 +74,45 @@ export const SettingsPresenter = () => {
         <div className="p-4 flex flex-col gap-3 bg-white rounded-lg shadow">
           <h2 className="font-bold text-lg text-gray-900">ユーザー情報編集</h2>
           <form className="space-y-4" onSubmit={handleSubmit(onSubmit)}>
-            <label className="block text-sm font-medium text-gray-900">プロフィール画像</label>
+            <label className="block text-sm font-medium text-gray-900">
+              プロフィール画像
+            </label>
             <div className="flex flex-col sm:flex-row justify-start items-center gap-6">
               <div className="max-w-[220px] w-1/4 max-h-[220px] h-1/4">
                 {imageUrl && imageFile ? (
-                  <img src={imageUrl} alt="アップロード画像" className="w-full h-full rounded-full" />
+                  {imageCropModalOpen &&
+                    <div>
+                    <ImageCropModal
+                      imageUrl={imageUrl}
+                      closeModal={closeImageCropModal}
+                    />
+                    // useeffect imageurlとimagefileを監視 値がかわｘったら発火 useeffectのなかでif文してみる
+                    {/* <img
+                      src={imageUrl}
+                      alt="アップロード画像"
+                      className="w-full h-full rounded-full"
+                    /> */}
+                  </div>}
+                  {ShowImageCropModal}
+                  
                 ) : (
-                  <img src={loginUser?.imageUrl} alt="現在設定されている画像" className="w-full h-full rounded-full" />
+                  <img
+                    src={loginUser?.imageUrl}
+                    alt="現在設定されている画像"
+                    className="w-full h-full rounded-full"
+                  />
                 )}
               </div>
-              <SettingsInputImage ref={fileInputRef} id={IMAGE_ID} onChange={handleFileChange} />
+              <SettingsInputImage
+                ref={fileInputRef}
+                id={IMAGE_ID}
+                onChange={handleFileChange}
+              />
             </div>
             <div>
-              <label className="block mb-2 text-sm font-medium text-gray-900 my-4">ユーザー名</label>
+              <label className="block mb-2 text-sm font-medium text-gray-900 my-4">
+                ユーザー名
+              </label>
               <input
                 type="text"
                 defaultValue={loginUser?.name ?? ""}
@@ -92,7 +135,9 @@ export const SettingsPresenter = () => {
           <h2 className="font-bold text-lg text-rhyth-dark-red">Danger Zone</h2>
           <div className="space-y-4">
             <div>
-              <label className="block text-sm font-medium text-gray-900">アカウント削除</label>
+              <label className="block text-sm font-medium text-gray-900">
+                アカウント削除
+              </label>
               <p className="text-sm mt-2">
                 アカウント削除を実行すると、このアカウントのデータは復元することができません。
               </p>

--- a/src/features/profile/settings/components/SettingsPresenter.tsx
+++ b/src/features/profile/settings/components/SettingsPresenter.tsx
@@ -1,26 +1,19 @@
 import { zodResolver } from "@hookform/resolvers/zod";
 import { useNavigate } from "@tanstack/react-router";
-import { FC, useRef, useState } from "react";
+import { useEffect, useRef, useState } from "react";
 import { useForm } from "react-hook-form";
 import { ConfirmModal, FormErrorMsg } from "../../../common/components";
 import { useMutateUser } from "../../api/user/hooks/useMutateUser";
 import { useQueryLoginUser } from "../../api/user/hooks/useQueryUser";
 import { BadgesBackButton } from "../../badges/components/BadgesBackButton";
-import {
-  TUserEditValidationSchema,
-  userEditValidationSchema,
-} from "../../libs/validation";
+import { TUserEditValidationSchema, userEditValidationSchema } from "../../libs/validation";
 import { useGetImageUrl } from "../hooks/useGetImageUrl";
 import { ImageCropModal } from "./ImageCropModal";
 import { SettingsInputImage } from "./SettingsInputImage";
 
 const IMAGE_ID = "imageId";
 
-type Props = {
-  onClickFn: () => void;
-};
-
-export const SettingsPresenter: FC<Props> = ({ onClickFn }) => {
+export const SettingsPresenter = () => {
   const navigation = useNavigate();
 
   const { data: loginUser } = useQueryLoginUser();
@@ -64,6 +57,12 @@ export const SettingsPresenter: FC<Props> = ({ onClickFn }) => {
     setImageCropModalOpen(false);
   };
 
+  useEffect(() => {
+    if (imageUrl && imageFile) {
+      ShowImageCropModal();
+    }
+  });
+
   return (
     <>
       <div className="flex flex-col space-y-5 w-full">
@@ -74,45 +73,31 @@ export const SettingsPresenter: FC<Props> = ({ onClickFn }) => {
         <div className="p-4 flex flex-col gap-3 bg-white rounded-lg shadow">
           <h2 className="font-bold text-lg text-gray-900">ユーザー情報編集</h2>
           <form className="space-y-4" onSubmit={handleSubmit(onSubmit)}>
-            <label className="block text-sm font-medium text-gray-900">
-              プロフィール画像
-            </label>
+            <label className="block text-sm font-medium text-gray-900">プロフィール画像</label>
             <div className="flex flex-col sm:flex-row justify-start items-center gap-6">
               <div className="max-w-[220px] w-1/4 max-h-[220px] h-1/4">
                 {imageUrl && imageFile ? (
-                  {imageCropModalOpen &&
+                  imageCropModalOpen ? (
                     <div>
-                    <ImageCropModal
-                      imageUrl={imageUrl}
-                      closeModal={closeImageCropModal}
-                    />
-                    // useeffect imageurlとimagefileを監視 値がかわｘったら発火 useeffectのなかでif文してみる
-                    {/* <img
+                      <ImageCropModal imageUrl={imageUrl} closeModal={closeImageCropModal} />
+                    </div>
+                  ) : (
+                    <p>エラー</p>
+                  )
+                ) : (
+                  <img src={loginUser?.imageUrl} alt="現在設定されている画像" className="w-full h-full rounded-full" />
+                )}
+                {/* // useeffect imageurlとimagefileを監視 値がかわｘったら発火 useeffectのなかでif文してみる */}
+                {/* <img
                       src={imageUrl}
                       alt="アップロード画像"
                       className="w-full h-full rounded-full"
                     /> */}
-                  </div>}
-                  {ShowImageCropModal}
-                  
-                ) : (
-                  <img
-                    src={loginUser?.imageUrl}
-                    alt="現在設定されている画像"
-                    className="w-full h-full rounded-full"
-                  />
-                )}
               </div>
-              <SettingsInputImage
-                ref={fileInputRef}
-                id={IMAGE_ID}
-                onChange={handleFileChange}
-              />
+              <SettingsInputImage ref={fileInputRef} id={IMAGE_ID} onChange={handleFileChange} />
             </div>
             <div>
-              <label className="block mb-2 text-sm font-medium text-gray-900 my-4">
-                ユーザー名
-              </label>
+              <label className="block mb-2 text-sm font-medium text-gray-900 my-4">ユーザー名</label>
               <input
                 type="text"
                 defaultValue={loginUser?.name ?? ""}
@@ -135,9 +120,7 @@ export const SettingsPresenter: FC<Props> = ({ onClickFn }) => {
           <h2 className="font-bold text-lg text-rhyth-dark-red">Danger Zone</h2>
           <div className="space-y-4">
             <div>
-              <label className="block text-sm font-medium text-gray-900">
-                アカウント削除
-              </label>
+              <label className="block text-sm font-medium text-gray-900">アカウント削除</label>
               <p className="text-sm mt-2">
                 アカウント削除を実行すると、このアカウントのデータは復元することができません。
               </p>

--- a/src/features/profile/settings/components/SettingsPresenter.tsx
+++ b/src/features/profile/settings/components/SettingsPresenter.tsx
@@ -87,12 +87,6 @@ export const SettingsPresenter = () => {
                 ) : (
                   <img src={loginUser?.imageUrl} alt="現在設定されている画像" className="w-full h-full rounded-full" />
                 )}
-                {/* // useeffect imageurlとimagefileを監視 値がかわｘったら発火 useeffectのなかでif文してみる */}
-                {/* <img
-                      src={imageUrl}
-                      alt="アップロード画像"
-                      className="w-full h-full rounded-full"
-                    /> */}
               </div>
               <SettingsInputImage ref={fileInputRef} id={IMAGE_ID} onChange={handleFileChange} />
             </div>

--- a/src/features/profile/settings/components/setCanvasPreview.ts
+++ b/src/features/profile/settings/components/setCanvasPreview.ts
@@ -1,16 +1,16 @@
 import { PixelCrop } from "react-image-crop";
 
-export const setCanvasPreview = (image, canvas, crop: PixelCrop) => {
-  const ctx = canvas.getContext("2d");
+export const setCanvasPreview = (image: HTMLImageElement | null, canvas: HTMLCanvasElement | null, crop: PixelCrop) => {
+  const ctx = canvas!.getContext("2d");
   if (!ctx) {
     throw new Error("2dコンテクストがありません");
   }
 
   const pixelRatio = window.devicePixelRatio;
-  const scaleX = image.naturalWidth / image.width;
-  const scaleY = image.naturalHeight / image.height;
-  canvas.width = Math.floor(crop.width * scaleX * pixelRatio);
-  canvas.height = Math.floor(crop.height * scaleY * pixelRatio);
+  const scaleX = image!.naturalWidth / image!.width;
+  const scaleY = image!.naturalHeight / image!.height;
+  canvas!.width = Math.floor(crop.width * scaleX * pixelRatio);
+  canvas!.height = Math.floor(crop.height * scaleY * pixelRatio);
 
   ctx.scale(pixelRatio, pixelRatio);
   ctx.imageSmoothingQuality = "high";
@@ -19,6 +19,16 @@ export const setCanvasPreview = (image, canvas, crop: PixelCrop) => {
   const cropX = crop.x * scaleX;
   const cropY = crop.y * scaleY;
   ctx.translate(-cropX, -cropY);
-  ctx.drawImage(image, 0, 0, image.naturalWidth, image.naturalHeight, 0, 0, image.naturalWidth, image.naturalHeight);
+  ctx.drawImage(
+    image!,
+    0,
+    0,
+    image!.naturalWidth,
+    image!.naturalHeight,
+    0,
+    0,
+    image!.naturalWidth,
+    image!.naturalHeight,
+  );
   ctx.restore();
 };

--- a/src/features/profile/settings/components/setCanvasPreview.ts
+++ b/src/features/profile/settings/components/setCanvasPreview.ts
@@ -1,0 +1,24 @@
+import { PixelCrop } from "react-image-crop";
+
+export const setCanvasPreview = (image, canvas, crop: PixelCrop) => {
+  const ctx = canvas.getContext("2d");
+  if (!ctx) {
+    throw new Error("2dコンテクストがありません");
+  }
+
+  const pixelRatio = window.devicePixelRatio;
+  const scaleX = image.naturalWidth / image.width;
+  const scaleY = image.naturalHeight / image.height;
+  canvas.width = Math.floor(crop.width * scaleX * pixelRatio);
+  canvas.height = Math.floor(crop.height * scaleY * pixelRatio);
+
+  ctx.scale(pixelRatio, pixelRatio);
+  ctx.imageSmoothingQuality = "high";
+  ctx.save();
+
+  const cropX = crop.x * scaleX;
+  const cropY = crop.y * scaleY;
+  ctx.translate(-cropX, -cropY);
+  ctx.drawImage(image, 0, 0, image.naturalWidth, image.naturalHeight, 0, 0, image.naturalWidth, image.naturalHeight);
+  ctx.restore();
+};

--- a/src/features/profile/settings/components/setCanvasPreview.ts
+++ b/src/features/profile/settings/components/setCanvasPreview.ts
@@ -1,6 +1,9 @@
 import { PixelCrop } from "react-image-crop";
 
 export const setCanvasPreview = (image: HTMLImageElement | null, canvas: HTMLCanvasElement | null, crop: PixelCrop) => {
+  if (canvas == null) {
+    return;
+  }
   const ctx = canvas!.getContext("2d");
   if (!ctx) {
     throw new Error("2dコンテクストがありません");


### PR DESCRIPTION
# 関連 issue
#183 [Web]プロフィール画像の切り取り機能を実装する

## 説明
プロフィールの画像切り取り機能を実装

## 動作確認手順
プロフィールページでプロフィール画像を選択すると切り取り画面が出てきます。
画像を切り取る->送信でコンソールに画像URLが出てくるのを確かめてください。

## 相談したいこと
モーダルを閉じれなくなりました。
画像を切り取ったときにプレビューが出るようにしたいです。
（そもそもプレビューはいらない・・・？）

## 確認して欲しいこと

## 参考 URL 等
