### PR TITLE
[Web] React Suspenseを利用したAPIハンドリングに変更するなどした

### DIFF
--- a/src/features/analytics/api/weeklyReport/hooks/useMutateWeeklyReport.ts
+++ b/src/features/analytics/api/weeklyReport/hooks/useMutateWeeklyReport.ts
@@ -3,7 +3,7 @@ import { createFactory } from "../../../../../api/weeklyReport/factory";
 import type { WeeklyReport } from "../../../../../api/weeklyReport/model";
 import { queryClient } from "../../../../../pkg/api/client/queryClient";
 import type { FetchError } from "../../../../../pkg/api/util/fetchError";
-import { notifyFailed, notifySuccess } from "../../../../../pkg/ui/toast";
+import { notifyWithToast } from "../../../../../pkg/ui/toast";
 
 export const useMutateWeeklyReport = () => {
   const weeklyReportFactory = createFactory();
@@ -29,10 +29,10 @@ export const useMutateWeeklyReport = () => {
           ),
         );
       }
-      notifySuccess("フィードバックを生成しました。");
+      notifyWithToast({ status: "success", msg: "フィードバックを生成しました。" });
     },
     onError: (err: FetchError) => {
-      notifyFailed("処理に失敗しました。");
+      notifyWithToast({ status: "error", msg: "処理に失敗しました。" });
       console.log(err);
     },
   });

--- a/src/features/analytics/api/weeklyReport/hooks/useMutateWeeklyReport.ts
+++ b/src/features/analytics/api/weeklyReport/hooks/useMutateWeeklyReport.ts
@@ -29,7 +29,6 @@ export const useMutateWeeklyReport = () => {
           ),
         );
       }
-      // queryClient.setQueryData<string>([`weeklyReportFeedBack-${data.weeklyReportId}`], data.feedBack);
       notifySuccess("フィードバックを生成しました。");
     },
     onError: (err: FetchError) => {

--- a/src/features/analytics/api/weeklyReport/hooks/useQueryWeeklyReport.ts
+++ b/src/features/analytics/api/weeklyReport/hooks/useQueryWeeklyReport.ts
@@ -1,11 +1,11 @@
-import { useQuery } from "@tanstack/react-query";
+import { useSuspenseQuery } from "@tanstack/react-query";
 import { createFactory } from "../../../../../api/weeklyReport/factory";
 import type { WeeklyReport } from "../../../../../api/weeklyReport/model";
 import type { FetchError } from "../../../../../pkg/api/util/fetchError";
 
 export const useQueryWeeklyReports = () => {
   const weeklyReportFactory = createFactory();
-  return useQuery<WeeklyReport[], FetchError>({
+  return useSuspenseQuery<WeeklyReport[], FetchError>({
     queryKey: ["weeklyReports"],
     queryFn: async () => {
       const weeklyReports = await weeklyReportFactory.listWeeklyReports();

--- a/src/features/analytics/components/AnalyticsAIFeedback.tsx
+++ b/src/features/analytics/components/AnalyticsAIFeedback.tsx
@@ -14,7 +14,7 @@ export const AnalyticsAIFeedback: FC<Props> = ({ summaryData, isLoading, onClick
         <span className="text-base font-bold">AIによるフィードバック</span>
         <button
           type="button"
-          className="flex gap-2 items-center ml-auto text-sm text-white bg-rhyth-light-blue hover:bg-rhyth-blue border border-rhyth-blue rounded-lg px-2 py-1"
+          className="flex gap-2 items-center ml-auto text-sm text-white bg-rhyth-light-blue hover:bg-rhyth-blue disabled:bg-rhyth-light-gray border border-rhyth-blue disabled:border-rhyth-light-gray rounded-lg px-2 py-1"
           disabled={isLoading}
           onClick={onClick}
         >

--- a/src/features/analytics/components/AnalyticsPresenter.tsx
+++ b/src/features/analytics/components/AnalyticsPresenter.tsx
@@ -1,6 +1,5 @@
 import { useState } from "react";
 import { formatDateTimeJP } from "../../../pkg/util/dayjs";
-import { Loading, LoadingContainer } from "../../common/components";
 import { useMutateWeeklyReport } from "../api/weeklyReport/hooks/useMutateWeeklyReport";
 import { useQueryWeeklyReports } from "../api/weeklyReport/hooks/useQueryWeeklyReport";
 import { AnalyticsAIFeedback } from "./AnalyticsAIFeedback";
@@ -9,7 +8,7 @@ import { AnalyticsCard } from "./AnalyticsCard";
 import { AnalyticsSwitchButton } from "./AnalyticsSwitchButton";
 
 export const AnalyticsPresenter = () => {
-  const { data: weeklyReports, isLoading: isLoadingWeeklyReports } = useQueryWeeklyReports();
+  const { data: weeklyReports } = useQueryWeeklyReports();
   const [currentIndex, setCurrentIndex] = useState<number>(0);
   const currentWeeklyReportsId = weeklyReports?.length ? weeklyReports[currentIndex].id : "";
   const { generateFeedBackMutation } = useMutateWeeklyReport();
@@ -34,11 +33,7 @@ export const AnalyticsPresenter = () => {
   };
   return (
     <>
-      {isLoadingWeeklyReports ? (
-        <LoadingContainer>
-          <Loading />
-        </LoadingContainer>
-      ) : weeklyReports?.length ? (
+      {weeklyReports?.length ? (
         <div className="flex flex-col items-center mx-auto">
           <div className="flex justify-between  w-full">
             {

--- a/src/features/common/components/Loading.tsx
+++ b/src/features/common/components/Loading.tsx
@@ -4,7 +4,7 @@ export const Loading = () => {
       <div role="status" className="flex">
         <svg
           aria-hidden="true"
-          className="inline w-8 h-8 text-rhyth-gray animate-spin fill-rhyth-blue"
+          className="inline w-6 h-6 text-rhyth-gray animate-spin fill-rhyth-light-blue"
           viewBox="0 0 100 100"
           fill="none"
           xmlns="http://www.w3.org/2000/svg"
@@ -18,7 +18,6 @@ export const Loading = () => {
             fill="currentFill"
           />
         </svg>
-        <span className="sr-only">Loading...</span>
       </div>
     </div>
   );

--- a/src/features/login/api/user/hooks/useMutateUser.tsx
+++ b/src/features/login/api/user/hooks/useMutateUser.tsx
@@ -3,7 +3,7 @@ import { useNavigate } from "@tanstack/react-router";
 import { createFactory } from "../../../../../api/user/factory";
 import type { AuthParams } from "../../../../../api/user/types";
 import type { FetchError } from "../../../../../pkg/api/util/fetchError";
-import { notifyFailed, notifySuccess } from "../../../../../pkg/ui/toast";
+import { notifyWithToast } from "../../../../../pkg/ui/toast";
 
 export const useMutateUser = () => {
   const userFactory = createFactory();
@@ -14,11 +14,11 @@ export const useMutateUser = () => {
       return await userFactory.auth(params);
     },
     onSuccess: () => {
-      notifySuccess("ログインに成功しました。");
+      notifyWithToast({ status: "success", msg: "ログインしました。" });
       navigate({ to: "/quests" });
     },
     onError: (err: FetchError) => {
-      notifyFailed("ログインに失敗しました。");
+      notifyWithToast({ status: "error", msg: "ログインに失敗しました。" });
       console.log(err);
     },
   });

--- a/src/features/manage/api/quest/hooks/useMutateQuest.ts
+++ b/src/features/manage/api/quest/hooks/useMutateQuest.ts
@@ -4,7 +4,7 @@ import type { Quest } from "../../../../../api/quest/model";
 import type { CreateQuestParams, DeleteQuestParams, UpdateQuestParams } from "../../../../../api/quest/types";
 import { queryClient } from "../../../../../pkg/api/client/queryClient";
 import type { FetchError } from "../../../../../pkg/api/util/fetchError";
-import { notifyFailed, notifySuccess } from "../../../../../pkg/ui/toast";
+import { notifyWithToast } from "../../../../../pkg/ui/toast";
 
 export const useMutateQuest = () => {
   const questFactory = createFactory();
@@ -18,10 +18,10 @@ export const useMutateQuest = () => {
       if (questList) {
         queryClient.setQueryData<Quest[]>(["quests"], [...questList, data]);
       }
-      notifySuccess("クエストを作成しました。");
+      notifyWithToast({ status: "success", msg: "クエストを作成しました。" });
     },
     onError: (err: FetchError) => {
-      notifyFailed("処理に失敗しました。");
+      notifyWithToast({ status: "error", msg: "処理に失敗しました。" });
       console.log(err);
     },
   });
@@ -38,10 +38,10 @@ export const useMutateQuest = () => {
           questList.map((quest) => (quest.id === data.id ? data : quest)),
         );
       }
-      notifySuccess("クエストを更新しました。");
+      notifyWithToast({ status: "success", msg: "クエストを更新しました。" });
     },
     onError: (err: FetchError) => {
-      notifyFailed("処理に失敗しました。");
+      notifyWithToast({ status: "error", msg: "処理に失敗しました。" });
       console.log(err);
     },
   });
@@ -58,10 +58,10 @@ export const useMutateQuest = () => {
           questList.filter((quest) => quest.id !== variables.id),
         );
       }
-      notifySuccess("クエストを削除しました。");
+      notifyWithToast({ status: "success", msg: "クエストを削除しました。" });
     },
     onError: (err: FetchError) => {
-      notifyFailed("処理に失敗しました。");
+      notifyWithToast({ status: "error", msg: "処理に失敗しました。" });
       console.log(err);
     },
   });

--- a/src/features/manage/api/quest/hooks/useQueryQuest.ts
+++ b/src/features/manage/api/quest/hooks/useQueryQuest.ts
@@ -1,11 +1,11 @@
-import { useQuery } from "@tanstack/react-query";
+import { useSuspenseQuery } from "@tanstack/react-query";
 import { createFactory } from "../../../../../api/quest/factory";
 import type { Quest } from "../../../../../api/quest/model";
 import type { FetchError } from "../../../../../pkg/api/util/fetchError";
 
 export const useQueryQuestList = () => {
   const questFactory = createFactory();
-  return useQuery<Quest[], FetchError>({
+  return useSuspenseQuery<Quest[], FetchError>({
     queryKey: ["quests"],
     queryFn: async () => {
       const quests = await questFactory.listQuests();

--- a/src/features/manage/components/ManagePresenter.tsx
+++ b/src/features/manage/components/ManagePresenter.tsx
@@ -2,7 +2,6 @@ import { useNavigate } from "@tanstack/react-router";
 import { useEffect, useState } from "react";
 import type { Quest } from "../../../api/quest/model";
 import type { Day, Difficulty } from "../../../api/quest/types";
-import { Loading, LoadingContainer } from "../../common/components";
 import { useSearchModalIsOpen, useSetSearchModalIsOpen } from "../../common/contexts/searchModalIsOpenContext";
 import { useQueryQuestList } from "../api/quest/hooks/useQueryQuest";
 import { DAYS } from "../common/constant/constant";
@@ -33,7 +32,7 @@ export const ManagePresenter = () => {
     setSearchModalIsOpen(false);
   };
 
-  const { data: questListData, isLoading: questListIsLoading } = useQueryQuestList();
+  const { data: questListData } = useQueryQuestList();
   const { data: tagListData } = useQueryTagList();
   const [questList, setQuestList] = useState<QuestWithTag[]>([]);
 
@@ -122,11 +121,7 @@ export const ManagePresenter = () => {
           </span>
         </button>
       </div>
-      {questListIsLoading ? (
-        <LoadingContainer>
-          <Loading />
-        </LoadingContainer>
-      ) : filterActivation ? (
+      {filterActivation ? (
         filteredData?.length ? (
           <ul className="mt-4 flex flex-col items-center gap-6">
             {filteredData?.map((quest) => {

--- a/src/features/manage/edit/components/EditPresenter.tsx
+++ b/src/features/manage/edit/components/EditPresenter.tsx
@@ -4,7 +4,7 @@ import { type FC, useEffect, useState } from "react";
 import { useForm } from "react-hook-form";
 import type { Day, Difficulty } from "../../../../api/quest/types";
 import { formatDateTimeOnlyTime } from "../../../../pkg/util/dayjs";
-import { ConfirmModal, FormErrorMsg, Loading, LoadingContainer } from "../../../common/components";
+import { ConfirmModal, FormErrorMsg } from "../../../common/components";
 import { BackButton } from "../../../common/components/BackButton";
 import { useQueryQuestList } from "../../../quests/api/quest/hooks/useQueryQuest";
 import { useMutateQuest } from "../../api/quest/hooks/useMutateQuest";
@@ -32,7 +32,7 @@ export const EditPresenter: FC<Props> = (props) => {
   const { quest_id } = props;
   const navigate = useNavigate();
   const { deleteQuestMutation, updateQuestMutation } = useMutateQuest();
-  const { data: questListData, isLoading } = useQueryQuestList();
+  const { data: questListData } = useQueryQuestList();
 
   const targetQuest = questListData?.find((v) => v.id === quest_id);
 
@@ -81,202 +81,196 @@ export const EditPresenter: FC<Props> = (props) => {
     <>
       <BackButton onClickNavigation={() => navigate({ to: "/manage" })} />
       <h1 className="text-xl font-cp-font text-rhyth-gray mt-4 mb-2">クエスト編集</h1>
-      {isLoading ? (
-        <LoadingContainer>
-          <Loading />
-        </LoadingContainer>
-      ) : (
-        <form className="bg-white px-3 py-2 rounded-lg shadow-lg" onSubmit={handleSubmit(onSubmit)}>
-          <div className="mt-2 flex flex-col gap-2">
-            <label htmlFor="edit-quest-title" className="text-base font-bold text-rhyth-gray">
-              タイトル
-            </label>
-            <input
-              type="text"
-              className="w-full p-2 border-2 border-rhyth-light-gray rounded-lg"
-              id="edit-quest-title"
-              defaultValue={targetQuest?.title}
-              placeholder="例) 朝のストレッチ"
-              {...register("title")}
-            />
+      <form className="bg-white px-3 py-2 rounded-lg shadow-lg" onSubmit={handleSubmit(onSubmit)}>
+        <div className="mt-2 flex flex-col gap-2">
+          <label htmlFor="edit-quest-title" className="text-base font-bold text-rhyth-gray">
+            タイトル
+          </label>
+          <input
+            type="text"
+            className="w-full p-2 border-2 border-rhyth-light-gray rounded-lg"
+            id="edit-quest-title"
+            defaultValue={targetQuest?.title}
+            placeholder="例) 朝のストレッチ"
+            {...register("title")}
+          />
+        </div>
+        {errors.title && <FormErrorMsg msg={errors.title.message ?? ""} />}
+        <div className="grid grid-cols-8 mt-4">
+          <div className="my-4">
+            <svg
+              className="w-6 h-6 text-rhyth-gray mt-2"
+              aria-hidden="true"
+              xmlns="http://www.w3.org/2000/svg"
+              fill="currentColor"
+              viewBox="0 0 24 24"
+            >
+              <path
+                fillRule="evenodd"
+                d="M2 12a10 10 0 1 1 20 0 10 10 0 0 1-20 0Zm11-4a1 1 0 1 0-2 0v4c0 .3.1.5.3.7l3 3a1 1 0 0 0 1.4-1.4L13 11.6V8Z"
+                clipRule="evenodd"
+              />
+            </svg>
           </div>
-          {errors.title && <FormErrorMsg msg={errors.title.message ?? ""} />}
-          <div className="grid grid-cols-8 mt-4">
-            <div className="my-4">
-              <svg
-                className="w-6 h-6 text-rhyth-gray mt-2"
-                aria-hidden="true"
-                xmlns="http://www.w3.org/2000/svg"
-                fill="currentColor"
-                viewBox="0 0 24 24"
-              >
-                <path
-                  fillRule="evenodd"
-                  d="M2 12a10 10 0 1 1 20 0 10 10 0 0 1-20 0Zm11-4a1 1 0 1 0-2 0v4c0 .3.1.5.3.7l3 3a1 1 0 0 0 1.4-1.4L13 11.6V8Z"
-                  clipRule="evenodd"
+          <div className="my-2 col-span-7">
+            <div className="grid grid-cols-5 my-2 items-center">
+              <p className="col-span-2 font-bold text-rhyth-gray">実施時刻</p>
+              <div className="col-span-3 flex justify-end items-center">
+                <input
+                  type="time"
+                  className="w-[85px] border-2 rounded p-1 mr-2 shadow-sm"
+                  defaultValue={targetQuest?.startsAt ? formatDateTimeOnlyTime(targetQuest.startsAt) : "00:00"}
+                  {...register("startsAt")}
                 />
-              </svg>
-            </div>
-            <div className="my-2 col-span-7">
-              <div className="grid grid-cols-5 my-2 items-center">
-                <p className="col-span-2 font-bold text-rhyth-gray">実施時刻</p>
-                <div className="col-span-3 flex justify-end items-center">
-                  <input
-                    type="time"
-                    className="w-[85px] border-2 rounded p-1 mr-2 shadow-sm"
-                    defaultValue={targetQuest?.startsAt ? formatDateTimeOnlyTime(targetQuest.startsAt) : "00:00"}
-                    {...register("startsAt")}
-                  />
-                  <span className="font-bold text-rhyth-gray">から</span>
-                </div>
-              </div>
-              {errors.startsAt && <FormErrorMsg msg={errors.startsAt.message ?? ""} />}
-              <div className="grid grid-cols-5 my-2 items-center">
-                <p className="col-span-2 font-bold text-rhyth-gray">取り組み時間</p>
-                <div className="col-span-3 flex justify-end items-center">
-                  <input
-                    type="number"
-                    min={1}
-                    className="w-[85px] border-2 rounded p-1 mr-2 shadow-sm"
-                    defaultValue={targetQuest?.minutes}
-                    {...register("minutes")}
-                  />
-                  <p className="font-bold text-rhyth-gray">分間</p>
-                </div>
-              </div>
-              {errors.minutes && <FormErrorMsg msg={errors.minutes.message ?? ""} />}
-              <div className="my-2">
-                <p className="block my-2 font-bold text-rhyth-gray">実施頻度</p>
-                <div className="flex mt-4 gap-1">
-                  {DAYS.map((day) => {
-                    return (
-                      <DayOfTheWeek
-                        key={day}
-                        day={convertEnToJPWeekday(day)}
-                        value={day}
-                        register={register}
-                        watch={watch}
-                      />
-                    );
-                  })}
-                </div>
-                {errors.days && <FormErrorMsg msg={errors.days.message ?? ""} />}
+                <span className="font-bold text-rhyth-gray">から</span>
               </div>
             </div>
-          </div>
-          <div className="mt-4">
-            <div className="flex items-center gap-2">
-              <svg
-                className="w-6 h-6 text-rhyth-gray"
-                aria-hidden="true"
-                xmlns="http://www.w3.org/2000/svg"
-                fill="currentColor"
-                viewBox="0 0 24 24"
-              >
-                <path d="M4 6a2 2 0 0 0-2 2v8c0 1.1.9 2 2 2h11.6c.5 0 1-.2 1.4-.5l4.4-4a2 2 0 0 0 0-3l-4.4-4a2 2 0 0 0-1.4-.5H4Z" />
-              </svg>
-              <p className="font-bold text-rhyth-gray">難易度</p>
+            {errors.startsAt && <FormErrorMsg msg={errors.startsAt.message ?? ""} />}
+            <div className="grid grid-cols-5 my-2 items-center">
+              <p className="col-span-2 font-bold text-rhyth-gray">取り組み時間</p>
+              <div className="col-span-3 flex justify-end items-center">
+                <input
+                  type="number"
+                  min={1}
+                  className="w-[85px] border-2 rounded p-1 mr-2 shadow-sm"
+                  defaultValue={targetQuest?.minutes}
+                  {...register("minutes")}
+                />
+                <p className="font-bold text-rhyth-gray">分間</p>
+              </div>
             </div>
-            <div className="flex justify-center gap-4 mt-4">
-              <button
-                type="button"
-                className={`w-1/4 border-2 flex justify-center items-center gap-1 p-2 rounded-md shadow-sm ${
-                  difficulty === "EASY" ? "bg-rhyth-blue" : "bg-white hover:bg-rhyth-bg-dark-gray"
-                }`}
-                onClick={() => {
-                  setDifficulty("EASY");
-                }}
-              >
-                <Star />
-              </button>
-              <button
-                type="button"
-                className={`w-1/4 border-2 flex justify-center items-center gap-1 p-2 rounded-md shadow-sm ${
-                  difficulty === "NORMAL" ? "bg-rhyth-blue" : "bg-white hover:bg-rhyth-bg-dark-gray"
-                }`}
-                onClick={() => {
-                  setDifficulty("NORMAL");
-                }}
-              >
-                <Star />
-                <Star />
-              </button>
-              <button
-                type="button"
-                className={`w-1/4 border-2 flex justify-center items-center gap-1 p-2 rounded-md shadow-sm ${
-                  difficulty === "HARD" ? "bg-rhyth-blue" : "bg-white hover:bg-rhyth-bg-dark-gray"
-                }`}
-                onClick={() => {
-                  setDifficulty("HARD");
-                }}
-              >
-                <Star />
-                <Star />
-                <Star />
-              </button>
+            {errors.minutes && <FormErrorMsg msg={errors.minutes.message ?? ""} />}
+            <div className="my-2">
+              <p className="block my-2 font-bold text-rhyth-gray">実施頻度</p>
+              <div className="flex mt-4 gap-1">
+                {DAYS.map((day) => {
+                  return (
+                    <DayOfTheWeek
+                      key={day}
+                      day={convertEnToJPWeekday(day)}
+                      value={day}
+                      register={register}
+                      watch={watch}
+                    />
+                  );
+                })}
+              </div>
+              {errors.days && <FormErrorMsg msg={errors.days.message ?? ""} />}
             </div>
           </div>
-          <div className="w-full gap-2 mt-6">
-            <div className="flex items-center gap-2 w-24">
-              <svg
-                className="w-6 h-6 text-rhyth-gray"
-                aria-hidden="true"
-                xmlns="http://www.w3.org/2000/svg"
-                width="24"
-                height="24"
-                fill="currentColor"
-                viewBox="0 0 24 24"
-              >
-                <path d="M18.045 3.007 12.31 3a1.965 1.965 0 0 0-1.4.585l-7.33 7.394a2 2 0 0 0 0 2.805l6.573 6.631a1.957 1.957 0 0 0 1.4.585 1.965 1.965 0 0 0 1.4-.585l7.409-7.477A2 2 0 0 0 21 11.479v-5.5a2.972 2.972 0 0 0-2.955-2.972Zm-2.452 6.438a1 1 0 1 1 0-2 1 1 0 0 1 0 2Z" />
-              </svg>
-              <label htmlFor="edit-quest-tag" className="text-base font-bold text-rhyth-gray">
-                タグ
-              </label>
-            </div>
-            <EditTagDropdown register={register} watch={watch} tagId={targetQuest?.tagId} />
-          </div>
-          <div className="w-full gap-2 mt-6">
-            <div className="flex items-center gap-2 w-24">
-              <svg
-                className="w-6 h-6 text-rhyth-gray"
-                aria-hidden="true"
-                xmlns="http://www.w3.org/2000/svg"
-                fill="none"
-                viewBox="0 0 24 24"
-              >
-                <path stroke="currentColor" strokeLinecap="round" strokeWidth="2" d="M5 7h14M5 12h14M5 17h10" />
-              </svg>
-              <label htmlFor="new-quest-description" className="text-base font-bold text-rhyth-gray">
-                メモ
-              </label>
-            </div>
-            <input
-              type="text"
-              id="edit-quest-description"
-              className="w-full border-2 p-2 rounded-md mt-4"
-              placeholder="例) 同じメニューを毎日欠かさず行う"
-              defaultValue={targetQuest?.description}
-              {...register("description")}
-            />
-          </div>
-          {errors.description && <FormErrorMsg msg={errors.description.message ?? ""} />}
-          <div className="flex flex-col mt-8 mb-4 gap-4">
-            <button
-              type="submit"
-              className="w-full text-white bg-rhyth-blue hover:bg-rhyth-hover-blue focus:ring-4 focus:ring-blue-300 font-medium rounded-lg text-base p-3 focus:outline-none shadow-lg"
+        </div>
+        <div className="mt-4">
+          <div className="flex items-center gap-2">
+            <svg
+              className="w-6 h-6 text-rhyth-gray"
+              aria-hidden="true"
+              xmlns="http://www.w3.org/2000/svg"
+              fill="currentColor"
+              viewBox="0 0 24 24"
             >
-              クエストを更新する
-            </button>
+              <path d="M4 6a2 2 0 0 0-2 2v8c0 1.1.9 2 2 2h11.6c.5 0 1-.2 1.4-.5l4.4-4a2 2 0 0 0 0-3l-4.4-4a2 2 0 0 0-1.4-.5H4Z" />
+            </svg>
+            <p className="font-bold text-rhyth-gray">難易度</p>
+          </div>
+          <div className="flex justify-center gap-4 mt-4">
             <button
-              onClick={() => setOpenModal(true)}
               type="button"
-              className="w-full text-white bg-rhyth-red hover:bg-rhyth-hover-red focus:ring-4 focus:ring-blue-300 font-medium rounded-lg text-base p-3 focus:outline-none shadow-lg"
+              className={`w-1/4 border-2 flex justify-center items-center gap-1 p-2 rounded-md shadow-sm ${
+                difficulty === "EASY" ? "bg-rhyth-blue" : "bg-white hover:bg-rhyth-bg-dark-gray"
+              }`}
+              onClick={() => {
+                setDifficulty("EASY");
+              }}
             >
-              クエストを削除する
+              <Star />
+            </button>
+            <button
+              type="button"
+              className={`w-1/4 border-2 flex justify-center items-center gap-1 p-2 rounded-md shadow-sm ${
+                difficulty === "NORMAL" ? "bg-rhyth-blue" : "bg-white hover:bg-rhyth-bg-dark-gray"
+              }`}
+              onClick={() => {
+                setDifficulty("NORMAL");
+              }}
+            >
+              <Star />
+              <Star />
+            </button>
+            <button
+              type="button"
+              className={`w-1/4 border-2 flex justify-center items-center gap-1 p-2 rounded-md shadow-sm ${
+                difficulty === "HARD" ? "bg-rhyth-blue" : "bg-white hover:bg-rhyth-bg-dark-gray"
+              }`}
+              onClick={() => {
+                setDifficulty("HARD");
+              }}
+            >
+              <Star />
+              <Star />
+              <Star />
             </button>
           </div>
-        </form>
-      )}
+        </div>
+        <div className="w-full gap-2 mt-6">
+          <div className="flex items-center gap-2 w-24">
+            <svg
+              className="w-6 h-6 text-rhyth-gray"
+              aria-hidden="true"
+              xmlns="http://www.w3.org/2000/svg"
+              width="24"
+              height="24"
+              fill="currentColor"
+              viewBox="0 0 24 24"
+            >
+              <path d="M18.045 3.007 12.31 3a1.965 1.965 0 0 0-1.4.585l-7.33 7.394a2 2 0 0 0 0 2.805l6.573 6.631a1.957 1.957 0 0 0 1.4.585 1.965 1.965 0 0 0 1.4-.585l7.409-7.477A2 2 0 0 0 21 11.479v-5.5a2.972 2.972 0 0 0-2.955-2.972Zm-2.452 6.438a1 1 0 1 1 0-2 1 1 0 0 1 0 2Z" />
+            </svg>
+            <label htmlFor="edit-quest-tag" className="text-base font-bold text-rhyth-gray">
+              タグ
+            </label>
+          </div>
+          <EditTagDropdown register={register} watch={watch} tagId={targetQuest?.tagId} />
+        </div>
+        <div className="w-full gap-2 mt-6">
+          <div className="flex items-center gap-2 w-24">
+            <svg
+              className="w-6 h-6 text-rhyth-gray"
+              aria-hidden="true"
+              xmlns="http://www.w3.org/2000/svg"
+              fill="none"
+              viewBox="0 0 24 24"
+            >
+              <path stroke="currentColor" strokeLinecap="round" strokeWidth="2" d="M5 7h14M5 12h14M5 17h10" />
+            </svg>
+            <label htmlFor="new-quest-description" className="text-base font-bold text-rhyth-gray">
+              メモ
+            </label>
+          </div>
+          <input
+            type="text"
+            id="edit-quest-description"
+            className="w-full border-2 p-2 rounded-md mt-4"
+            placeholder="例) 同じメニューを毎日欠かさず行う"
+            defaultValue={targetQuest?.description}
+            {...register("description")}
+          />
+        </div>
+        {errors.description && <FormErrorMsg msg={errors.description.message ?? ""} />}
+        <div className="flex flex-col mt-8 mb-4 gap-4">
+          <button
+            type="submit"
+            className="w-full text-white bg-rhyth-blue hover:bg-rhyth-hover-blue focus:ring-4 focus:ring-blue-300 font-medium rounded-lg text-base p-3 focus:outline-none shadow-lg"
+          >
+            クエストを更新する
+          </button>
+          <button
+            onClick={() => setOpenModal(true)}
+            type="button"
+            className="w-full text-white bg-rhyth-red hover:bg-rhyth-hover-red focus:ring-4 focus:ring-blue-300 font-medium rounded-lg text-base p-3 focus:outline-none shadow-lg"
+          >
+            クエストを削除する
+          </button>
+        </div>
+      </form>
       {openModal && (
         <ConfirmModal
           text={"本当に削除しますか?"}

--- a/src/features/manage/edit/components/EditTagDropdown.tsx
+++ b/src/features/manage/edit/components/EditTagDropdown.tsx
@@ -1,6 +1,5 @@
 import type { FC } from "react";
 import type { UseFormRegister, UseFormWatch } from "react-hook-form";
-import { Loading, LoadingContainer } from "../../../common/components";
 import { TagItem } from "../../common/components/TagItem";
 import type { TManageValidationSchema } from "../../common/libs/validation";
 import { useQueryTagList } from "../../tags/api/tag/hooks/useQueryTag";
@@ -12,7 +11,7 @@ type Props = {
 };
 
 export const EditTagDropdown: FC<Props> = ({ register, watch, tagId }) => {
-  const { data: tagItems, isLoading } = useQueryTagList();
+  const { data: tagItems } = useQueryTagList();
   const tagIdForColorSelect = watch("tagId");
 
   const selectColorLabel = (tagId: string | undefined) => {
@@ -39,11 +38,7 @@ export const EditTagDropdown: FC<Props> = ({ register, watch, tagId }) => {
 
   return (
     <>
-      {isLoading ? (
-        <LoadingContainer>
-          <Loading />
-        </LoadingContainer>
-      ) : tagItems?.length ? (
+      {tagItems?.length ? (
         <select
           className={`w-full border-2 p-2 rounded-md mt-4 ${selectColorLabel(tagIdForColorSelect)}`}
           id="edit-quest-description"

--- a/src/features/manage/new/components/NewPresenter.tsx
+++ b/src/features/manage/new/components/NewPresenter.tsx
@@ -237,7 +237,8 @@ export const NewPresenter = () => {
         {errors.description && <FormErrorMsg msg={errors.description.message ?? ""} />}
         <button
           type="submit"
-          className="w-full mt-8 text-white bg-rhyth-blue hover:bg-rhyth-hover-blue focus:ring-4 focus:ring-blue-300 font-medium rounded-lg text-base my-4 p-3 shadow-lg focus:outline-none"
+          className="w-full mt-8 text-white bg-rhyth-blue hover:bg-rhyth-hover-blue disabled:bg-rhyth-light-gray focus:ring-4 focus:ring-blue-300 font-medium rounded-lg text-base my-4 p-3 shadow-lg focus:outline-none"
+          disabled={createQuestMutation.isPending}
         >
           クエストを作成する
         </button>

--- a/src/features/manage/new/components/NewTagDropdown.tsx
+++ b/src/features/manage/new/components/NewTagDropdown.tsx
@@ -1,6 +1,5 @@
 import type { FC } from "react";
 import type { UseFormRegister, UseFormWatch } from "react-hook-form";
-import { Loading, LoadingContainer } from "../../../common/components";
 import { TagItem } from "../../common/components/TagItem";
 import type { TManageValidationSchema } from "../../common/libs/validation";
 import { useQueryTagList } from "../../tags/api/tag/hooks/useQueryTag";
@@ -11,7 +10,7 @@ type Props = {
 };
 
 export const NewTagDropdown: FC<Props> = ({ register, watch }) => {
-  const { data: tagItems, isLoading } = useQueryTagList();
+  const { data: tagItems } = useQueryTagList();
   const tagIdForColorSelect = watch("tagId");
 
   const selectColorLabel = (tagId: string | undefined) => {
@@ -38,11 +37,7 @@ export const NewTagDropdown: FC<Props> = ({ register, watch }) => {
 
   return (
     <>
-      {isLoading ? (
-        <LoadingContainer>
-          <Loading />
-        </LoadingContainer>
-      ) : tagItems?.length ? (
+      {tagItems?.length ? (
         <select
           className={`w-full border-2 p-2 rounded-md mt-4 ${selectColorLabel(tagIdForColorSelect)}`}
           id="new-quest-description"

--- a/src/features/manage/tags/api/tag/hooks/useMutateTag.ts
+++ b/src/features/manage/tags/api/tag/hooks/useMutateTag.ts
@@ -4,7 +4,7 @@ import type { Tag } from "../../../../../../api/tag/model";
 import type { CreateTagParams, UpdateTagParams } from "../../../../../../api/tag/type";
 import { queryClient } from "../../../../../../pkg/api/client/queryClient";
 import type { FetchError } from "../../../../../../pkg/api/util/fetchError";
-import { notifyFailed, notifySuccess } from "../../../../../../pkg/ui/toast";
+import { notifyWithToast } from "../../../../../../pkg/ui/toast";
 
 export const useMutateTag = () => {
   const tagFactory = createFactory();
@@ -18,10 +18,10 @@ export const useMutateTag = () => {
       if (tagList) {
         queryClient.setQueryData<Tag[]>(["tags"], [...tagList, data]);
       }
-      notifySuccess("タグを作成しました。");
+      notifyWithToast({ status: "success", msg: "タグを作成しました。" });
     },
     onError: (err: FetchError) => {
-      notifyFailed("処理に失敗しました。");
+      notifyWithToast({ status: "error", msg: "処理に失敗しました。" });
       console.log(err);
     },
   });
@@ -38,10 +38,10 @@ export const useMutateTag = () => {
           tagList.map((tag) => (tag.id === data.id ? data : tag)),
         );
       }
-      notifySuccess("タグを更新しました。");
+      notifyWithToast({ status: "success", msg: "タグを更新しました。" });
     },
     onError: (err: FetchError) => {
-      notifyFailed("処理に失敗しました。");
+      notifyWithToast({ status: "error", msg: "処理に失敗しました。" });
       console.log(err);
     },
   });
@@ -58,10 +58,10 @@ export const useMutateTag = () => {
           tagList.filter((tag) => tag.id !== variables.id),
         );
       }
-      notifySuccess("タグを削除しました。");
+      notifyWithToast({ status: "success", msg: "タグを削除しました。" });
     },
     onError: (err: FetchError) => {
-      notifyFailed("処理に失敗しました。");
+      notifyWithToast({ status: "error", msg: "処理に失敗しました。" });
       console.log(err);
     },
   });

--- a/src/features/manage/tags/api/tag/hooks/useQueryTag.ts
+++ b/src/features/manage/tags/api/tag/hooks/useQueryTag.ts
@@ -1,11 +1,11 @@
-import { useQuery } from "@tanstack/react-query";
+import { useSuspenseQuery } from "@tanstack/react-query";
 import { createFactory } from "../../../../../../api/tag/factory";
 import type { Tag } from "../../../../../../api/tag/model";
 import type { FetchError } from "../../../../../../pkg/api/util/fetchError";
 
 export const useQueryTagList = () => {
   const tagFactory = createFactory();
-  return useQuery<Tag[], FetchError>({
+  return useSuspenseQuery<Tag[], FetchError>({
     queryKey: ["tags"],
     queryFn: async () => {
       const tags = await tagFactory.listTags();

--- a/src/features/manage/tags/components/TagsNewModal.tsx
+++ b/src/features/manage/tags/components/TagsNewModal.tsx
@@ -42,12 +42,10 @@ export const TagsNewModal: FC<Props> = ({ modalType, closeModal }) => {
   return (
     <ModalBase onClickClose={closeModal}>
       <div className="order relative bg-white rounded-lg shadow">
-        {/* <!-- Modal header --> */}
         <div className="flex items-center justify-between p-4 md:p-4 rounded-t border-b">
           <h3 className="font-cp-font text-xl font-bold text-rhyth-dark-blue">{modalType}</h3>
           <ModalHeaderCloseButton onClickClose={closeModal} />
         </div>
-        {/* <!-- Modal body --> */}
         <div className="p-4 md:p-4">
           <form className="space-y-3" onSubmit={handleSubmit(onSubmit)}>
             <div className="flex items-center justify-between">
@@ -94,7 +92,8 @@ export const TagsNewModal: FC<Props> = ({ modalType, closeModal }) => {
             </div>
             <button
               type="submit"
-              className="w-full text-white bg-rhyth-light-blue hover:bg-rhyth-blue font-medium rounded-lg text-sm px-5 py-2.5 text-center shadow-md"
+              className="w-full text-white bg-rhyth-light-blue hover:bg-rhyth-blue disabled:bg-rhyth-light-gray font-medium rounded-lg text-sm px-5 py-2.5 text-center shadow-md"
+              disabled={createTagMutation.isPending}
             >
               決定する
             </button>

--- a/src/features/manage/tags/components/TagsPresenter.tsx
+++ b/src/features/manage/tags/components/TagsPresenter.tsx
@@ -1,6 +1,5 @@
 import { useNavigate } from "@tanstack/react-router";
 import { useState } from "react";
-import { Loading, LoadingContainer } from "../../../common/components";
 import { BackButton } from "../../../common/components/BackButton";
 import { ConfirmModal } from "../../../common/components/ConfirmModal";
 import { useMutateTag } from "../api/tag/hooks/useMutateTag";
@@ -18,7 +17,7 @@ export const TagsPresenter = () => {
 
   const [selectedTagId, setSelectedTagId] = useState<string>();
 
-  const { data: tagItems, isLoading } = useQueryTagList();
+  const { data: tagItems } = useQueryTagList();
 
   const { deleteTagMutation } = useMutateTag();
 
@@ -58,11 +57,7 @@ export const TagsPresenter = () => {
           <TagsNewButton onClickFn={openTagsNewModal} />
         </div>
         <div className="text-rhyth-dark-blue">
-          {isLoading ? (
-            <LoadingContainer>
-              <Loading />
-            </LoadingContainer>
-          ) : tagItems?.length ? (
+          {tagItems?.length ? (
             <ul className="text-md font-bold bg-white border-2 border-rhyth-light-gray rounded-lg shadow-md">
               {tagItems.map((item) => (
                 <TagsItem

--- a/src/features/profile/api/user/hooks/useMutateUser.ts
+++ b/src/features/profile/api/user/hooks/useMutateUser.ts
@@ -5,7 +5,7 @@ import type { User } from "../../../../../api/user/model";
 import type { UpdateLoginUserParams } from "../../../../../api/user/types";
 import { queryClient } from "../../../../../pkg/api/client/queryClient";
 import type { FetchError } from "../../../../../pkg/api/util/fetchError";
-import { notifyFailed, notifySuccess } from "../../../../../pkg/ui/toast";
+import { notifyWithToast } from "../../../../../pkg/ui/toast";
 
 export const useMutateUser = () => {
   const userFactory = createFactory();
@@ -26,10 +26,10 @@ export const useMutateUser = () => {
           imageUrl: data.imageUrl,
         });
       }
-      notifySuccess("正常に更新しました。");
+      notifyWithToast({ status: "success", msg: "ユーザー情報を更新しました。" });
     },
     onError: (err: FetchError) => {
-      notifyFailed("処理に失敗しました。");
+      notifyWithToast({ status: "error", msg: "処理に失敗しました。" });
       console.log(err);
     },
   });
@@ -40,7 +40,7 @@ export const useMutateUser = () => {
       navigate({ to: "/" });
     },
     onError: (err: FetchError) => {
-      notifyFailed("ログアウトに失敗しました。");
+      notifyWithToast({ status: "error", msg: "処理に失敗しました。" });
       console.log(err);
     },
   });
@@ -51,7 +51,7 @@ export const useMutateUser = () => {
       navigate({ to: "/" });
     },
     onError: (err: FetchError) => {
-      notifyFailed("アカウントの削除に失敗しました。");
+      notifyWithToast({ status: "error", msg: "処理に失敗しました。" });
       console.log(err);
     },
   });

--- a/src/features/profile/api/user/hooks/useQueryUser.ts
+++ b/src/features/profile/api/user/hooks/useQueryUser.ts
@@ -1,11 +1,11 @@
-import { useQuery } from "@tanstack/react-query";
+import { useSuspenseQuery } from "@tanstack/react-query";
 import { createFactory } from "../../../../../api/user/factory";
 import type { User } from "../../../../../api/user/model";
 import type { FetchError } from "../../../../../pkg/api/util/fetchError";
 
 export const useQueryLoginUser = () => {
   const userFactory = createFactory();
-  return useQuery<User, FetchError>({
+  return useSuspenseQuery<User, FetchError>({
     queryKey: ["user"],
     queryFn: async () => {
       const user = await userFactory.getLoginUser();

--- a/src/features/profile/badges/api/badge/hooks/useMutateBadge.ts
+++ b/src/features/profile/badges/api/badge/hooks/useMutateBadge.ts
@@ -4,7 +4,7 @@ import type { Badge } from "../../../../../../api/badge/model";
 import type { AchieveBadgeParams, PinBadgeParams } from "../../../../../../api/badge/type";
 import { queryClient } from "../../../../../../pkg/api/client/queryClient";
 import type { FetchError } from "../../../../../../pkg/api/util/fetchError";
-import { notifyFailed, notifySuccess } from "../../../../../../pkg/ui/toast";
+import { notifyWithToast } from "../../../../../../pkg/ui/toast";
 
 export const useMutateBadge = () => {
   const badgeFactory = createFactory();
@@ -21,10 +21,10 @@ export const useMutateBadge = () => {
           badgeList.map((badge) => (badge.id === data.id ? data : badge)),
         );
       }
-      notifySuccess("新しいバッジを取得しました。");
+      notifyWithToast({ status: "success", msg: "新しいバッジを取得しました。" });
     },
     onError: (err: FetchError) => {
-      notifyFailed("処理に失敗しました。");
+      notifyWithToast({ status: "error", msg: "処理に失敗しました。" });
       console.log(err);
     },
   });
@@ -41,10 +41,10 @@ export const useMutateBadge = () => {
           badgeList.map((badge) => (badge.id === data.id ? data : badge)),
         );
       }
-      notifySuccess("バッジをピン留めしました。");
+      notifyWithToast({ status: "success", msg: "バッジをピン留めしました。" });
     },
     onError: (err: FetchError) => {
-      notifyFailed("処理に失敗しました。");
+      notifyWithToast({ status: "error", msg: "処理に失敗しました。" });
       console.log(err);
     },
   });
@@ -61,10 +61,10 @@ export const useMutateBadge = () => {
           badgeList.map((badge) => (badge.id === data.id ? data : badge)),
         );
       }
-      notifySuccess("バッジのピン留めを解除しました。");
+      notifyWithToast({ status: "success", msg: "バッジのピン留めを解除しました。" });
     },
     onError: (err: FetchError) => {
-      notifyFailed("処理に失敗しました。");
+      notifyWithToast({ status: "error", msg: "処理に失敗しました。" });
       console.log(err);
     },
   });

--- a/src/features/profile/badges/api/badge/hooks/useQueryBadge.ts
+++ b/src/features/profile/badges/api/badge/hooks/useQueryBadge.ts
@@ -1,11 +1,11 @@
-import { useQuery } from "@tanstack/react-query";
+import { useSuspenseQuery } from "@tanstack/react-query";
 import { createFactory } from "../../../../../../api/badge/factory";
 import type { Badge } from "../../../../../../api/badge/model";
 import type { FetchError } from "../../../../../../pkg/api/util/fetchError";
 
 export const useQueryBadgeList = () => {
   const badgeFactory = createFactory();
-  return useQuery<Badge[], FetchError>({
+  return useSuspenseQuery<Badge[], FetchError>({
     queryKey: ["badges"],
     queryFn: async () => {
       const badges = await badgeFactory.listBadges();

--- a/src/features/profile/badges/components/BadgesPresenter.tsx
+++ b/src/features/profile/badges/components/BadgesPresenter.tsx
@@ -1,5 +1,4 @@
 import { useNavigate } from "@tanstack/react-router";
-import { Loading, LoadingContainer } from "../../../common/components";
 import { BackButton } from "../../../common/components/BackButton";
 import { useQueryBadgeList } from "../api/badge/hooks/useQueryBadge";
 import { BadgeCard } from "./BadgeCard";
@@ -7,7 +6,7 @@ import { BadgeCard } from "./BadgeCard";
 export const BadgesPresenter = () => {
   const navigation = useNavigate();
 
-  const { data: badgeList, isLoading } = useQueryBadgeList();
+  const { data: badgeList } = useQueryBadgeList();
 
   return (
     <div className="flex flex-col items-center w-full">
@@ -21,30 +20,24 @@ export const BadgesPresenter = () => {
         </div>
         <p className="flex text-2xl justify-center font-bold">獲得バッジ一覧</p>
       </div>
-      {isLoading ? (
-        <LoadingContainer>
-          <Loading />
-        </LoadingContainer>
-      ) : (
-        <ul className="flex flex-col items-center mt-3 gap-3 w-full h-full">
-          {badgeList?.map((badge) => {
-            return (
-              <li key={badge.id} className="w-full">
-                <BadgeCard
-                  id={badge.id}
-                  name={badge.name}
-                  description={badge.description}
-                  imageType={badge.imageType}
-                  frameColor={badge.frameColor}
-                  isPinned={badge.isPinned}
-                  obtainedAt={badge.obtainedAt}
-                  unlockable={badge.unlockable}
-                />
-              </li>
-            );
-          })}
-        </ul>
-      )}
+      <ul className="flex flex-col items-center mt-3 gap-3 w-full h-full">
+        {badgeList?.map((badge) => {
+          return (
+            <li key={badge.id} className="w-full">
+              <BadgeCard
+                id={badge.id}
+                name={badge.name}
+                description={badge.description}
+                imageType={badge.imageType}
+                frameColor={badge.frameColor}
+                isPinned={badge.isPinned}
+                obtainedAt={badge.obtainedAt}
+                unlockable={badge.unlockable}
+              />
+            </li>
+          );
+        })}
+      </ul>
     </div>
   );
 };

--- a/src/features/profile/components/ProfilePresenter.tsx
+++ b/src/features/profile/components/ProfilePresenter.tsx
@@ -1,5 +1,4 @@
 import { useState } from "react";
-import { Loading, LoadingContainer } from "../../common/components";
 import { useQueryLoginUser } from "../api/user/hooks/useQueryUser";
 import { useQueryBadgeList } from "../badges/api/badge/hooks/useQueryBadge";
 import { Badge } from "../badges/components/badge/Badge";
@@ -9,7 +8,7 @@ import { ProfileLogoutModalButton } from "./ProfileLogoutModalButton";
 import { ProfileUserSettingsModalButton } from "./ProfileUserSettingsModalButton";
 
 export const ProfilePresenter = () => {
-  const { data: loginUser, isLoading } = useQueryLoginUser();
+  const { data: loginUser } = useQueryLoginUser();
   const { data: badgeList } = useQueryBadgeList();
 
   const [isLogoutModalOpen, setIsLogoutModalOpen] = useState<boolean>(false);
@@ -26,43 +25,37 @@ export const ProfilePresenter = () => {
 
   return (
     <>
-      {isLoading ? (
-        <LoadingContainer>
-          <Loading />
-        </LoadingContainer>
-      ) : (
-        <div className="flex flex-col items-center gap-4">
-          <div className="w-full p-5 bg-white border border-gray-200 rounded-lg shadow">
-            <div className="flex justify-between items-center gap-4 box-border ">
-              <div className="w-20 md:w-32 h-20 md:h-32">
-                <img src={loginUser?.imageUrl} alt="プロフィール画像" className="w-full h-full rounded-full" />
-              </div>
-              <p className="text-3xl font-extrabold text-rhyth-dark-blue">{loginUser?.name}</p>
+      <div className="flex flex-col items-center gap-4">
+        <div className="w-full p-5 bg-white border border-gray-200 rounded-lg shadow">
+          <div className="flex justify-between items-center gap-4 box-border ">
+            <div className="w-20 md:w-32 h-20 md:h-32">
+              <img src={loginUser?.imageUrl} alt="プロフィール画像" className="w-full h-full rounded-full" />
             </div>
-            <div className="flex justify-between mt-4">
-              <div className="flex items-end gap-7 text-white bg-rhyth-light-blue focus:outline-none focus:ring-4 font-extrabold text-3xl px-3 py-2 mb-2 -ml-5">
-                <div className="text-base">Lv. </div>
-                <div>{loginUser?.level}</div>
-              </div>
-              <div className="flex justify-end w-2/3 gap-3">
-                {pinnedBadgeList?.map((badge) => {
-                  return (
-                    <div className="flex h-full w-1/3" key={badge.id}>
-                      <Badge imageType={badge.imageType} frameColor={badge.frameColor} />
-                    </div>
-                  );
-                })}
-              </div>
-            </div>
+            <p className="text-3xl font-extrabold text-rhyth-dark-blue">{loginUser?.name}</p>
           </div>
-          <ProfileExpCard currentLevel={loginUser?.level ?? 1} exp={loginUser?.exp ?? 0} />
-          <div className="w-full">
-            <ProfileUserSettingsModalButton />
-            <ProfileLogoutModalButton onClickFn={openLogoutModal} />
+          <div className="flex justify-between mt-4">
+            <div className="flex items-end gap-7 text-white bg-rhyth-light-blue focus:outline-none focus:ring-4 font-extrabold text-3xl px-3 py-2 mb-2 -ml-5">
+              <div className="text-base">Lv. </div>
+              <div>{loginUser?.level}</div>
+            </div>
+            <div className="flex justify-end w-2/3 gap-3">
+              {pinnedBadgeList?.map((badge) => {
+                return (
+                  <div className="flex h-full w-1/3" key={badge.id}>
+                    <Badge imageType={badge.imageType} frameColor={badge.frameColor} />
+                  </div>
+                );
+              })}
+            </div>
           </div>
         </div>
-      )}
-      {isLogoutModalOpen && <ProfileLogoutModal onClickFn={closeLogoutModal} />}
+        <ProfileExpCard currentLevel={loginUser?.level ?? 1} exp={loginUser?.exp ?? 0} />
+        <div className="w-full">
+          <ProfileUserSettingsModalButton />
+          <ProfileLogoutModalButton onClickFn={openLogoutModal} />
+        </div>
+      </div>
+      {isLogoutModalOpen && <ProfileLogoutModal onClickFn={closeLogoutModal} />}{" "}
     </>
   );
 };

--- a/src/features/profile/settings/components/SettingsPresenter.tsx
+++ b/src/features/profile/settings/components/SettingsPresenter.tsx
@@ -2,7 +2,7 @@ import { zodResolver } from "@hookform/resolvers/zod";
 import { useNavigate } from "@tanstack/react-router";
 import { type ChangeEvent, useEffect, useRef, useState } from "react";
 import { useForm } from "react-hook-form";
-import { ConfirmModal, FormErrorMsg, Loading, LoadingContainer } from "../../../common/components";
+import { ConfirmModal, FormErrorMsg } from "../../../common/components";
 import { BackButton } from "../../../common/components/BackButton";
 import { useMutateUser } from "../../api/user/hooks/useMutateUser";
 import { useQueryLoginUser } from "../../api/user/hooks/useQueryUser";
@@ -13,7 +13,7 @@ import { SettingsInputImage } from "./SettingsInputImage";
 
 export const SettingsPresenter = () => {
   const [openModal, setOpenModal] = useState(false);
-  const { data: loginUserData, isLoading } = useQueryLoginUser();
+  const { data: loginUserData } = useQueryLoginUser();
   const { updateUserMutation, deleteUserMutation } = useMutateUser();
   const navigation = useNavigate();
 
@@ -70,66 +70,60 @@ export const SettingsPresenter = () => {
 
   return (
     <>
-      {isLoading ? (
-        <LoadingContainer>
-          <Loading />
-        </LoadingContainer>
-      ) : (
-        <div className="flex flex-col space-y-5 w-full">
-          <div className="flex justify-start gap-3">
-            <BackButton onClickNavigation={() => navigation({ to: "/profile" })} />
-          </div>
-          <h1 className="flex text-2xl justify-center font-bold">ユーザー設定</h1>
-          <div className="p-4 flex flex-col gap-3 bg-white rounded-lg shadow">
-            <h2 className="font-bold text-lg text-gray-900">ユーザー情報編集</h2>
-            <form className="space-y-4" onSubmit={handleSubmit(onSubmitUpdate)}>
-              <label className="block text-sm font-medium text-gray-900">プロフィール画像</label>
-              <div className="flex flex-col sm:flex-row justify-start items-center gap-6">
-                <div className="w-20 md:w-32 h-20 md:h-32">
-                  <img src={profileImage} alt="現在のプロフィール画像" className="w-full h-full rounded-full" />
-                </div>
-                <SettingsInputImage ref={fileInputRef} onChange={handleFileChange} />
+      <div className="flex flex-col space-y-5 w-full">
+        <div className="flex justify-start gap-3">
+          <BackButton onClickNavigation={() => navigation({ to: "/profile" })} />
+        </div>
+        <h1 className="flex text-2xl justify-center font-bold">ユーザー設定</h1>
+        <div className="p-4 flex flex-col gap-3 bg-white rounded-lg shadow">
+          <h2 className="font-bold text-lg text-gray-900">ユーザー情報編集</h2>
+          <form className="space-y-4" onSubmit={handleSubmit(onSubmitUpdate)}>
+            <label className="block text-sm font-medium text-gray-900">プロフィール画像</label>
+            <div className="flex flex-col sm:flex-row justify-start items-center gap-6">
+              <div className="w-20 md:w-32 h-20 md:h-32">
+                <img src={profileImage} alt="現在のプロフィール画像" className="w-full h-full rounded-full" />
               </div>
-              <div>
-                <label className="block mb-2 text-sm font-medium text-gray-900 my-4">ユーザー名</label>
-                <input
-                  type="text"
-                  defaultValue={loginUserData?.name ?? ""}
-                  className="bg-gray-50 border border-gray-300 text-gray-900 text-sm rounded-lg focus:ring-blue-500 focus:border-blue-500 block w-full p-2.5"
-                  placeholder="あなたの名前"
-                  {...register("name")}
-                  required
-                />
-                {errors.name && <FormErrorMsg msg={errors.name.message ?? ""} />}
-              </div>
-              <button
-                type="submit"
-                className="w-full text-white bg-rhyth-light-blue hover:bg-rhyth-blue focus:ring-4 focus:outline-none focus:ring-blue-300 font-medium rounded-lg text-sm px-5 py-2.5 text-center"
-              >
-                保存
-              </button>
-            </form>
-          </div>
-          <div className="p-4 flex flex-col gap-3 order relative bg-red-100 rounded-lg shadow">
-            <h2 className="font-bold text-lg text-rhyth-dark-red">Danger Zone</h2>
-            <div className="space-y-4">
-              <div>
-                <label className="block text-sm font-medium text-gray-900">アカウント削除</label>
-                <p className="text-sm mt-2">
-                  アカウント削除を実行すると、このアカウントのデータは復元することができません。
-                </p>
-              </div>
-              <button
-                type="button"
-                className="w-full text-white bg-rhyth-red hover:bg-rhyth-dark-red focus:ring-4 focus:outline-none focus:ring-blue-300 font-medium rounded-lg text-sm px-5 py-2.5 mt-2 text-center"
-                onClick={() => setOpenModal(true)}
-              >
-                アカウント削除
-              </button>
+              <SettingsInputImage ref={fileInputRef} onChange={handleFileChange} />
             </div>
+            <div>
+              <label className="block mb-2 text-sm font-medium text-gray-900 my-4">ユーザー名</label>
+              <input
+                type="text"
+                defaultValue={loginUserData?.name ?? ""}
+                className="bg-gray-50 border border-gray-300 text-gray-900 text-sm rounded-lg focus:ring-blue-500 focus:border-blue-500 block w-full p-2.5"
+                placeholder="あなたの名前"
+                {...register("name")}
+                required
+              />
+              {errors.name && <FormErrorMsg msg={errors.name.message ?? ""} />}
+            </div>
+            <button
+              type="submit"
+              className="w-full text-white bg-rhyth-light-blue hover:bg-rhyth-blue focus:ring-4 focus:outline-none focus:ring-blue-300 font-medium rounded-lg text-sm px-5 py-2.5 text-center"
+            >
+              保存
+            </button>
+          </form>
+        </div>
+        <div className="p-4 flex flex-col gap-3 order relative bg-red-100 rounded-lg shadow">
+          <h2 className="font-bold text-lg text-rhyth-dark-red">Danger Zone</h2>
+          <div className="space-y-4">
+            <div>
+              <label className="block text-sm font-medium text-gray-900">アカウント削除</label>
+              <p className="text-sm mt-2">
+                アカウント削除を実行すると、このアカウントのデータは復元することができません。
+              </p>
+            </div>
+            <button
+              type="button"
+              className="w-full text-white bg-rhyth-red hover:bg-rhyth-dark-red focus:ring-4 focus:outline-none focus:ring-blue-300 font-medium rounded-lg text-sm px-5 py-2.5 mt-2 text-center"
+              onClick={() => setOpenModal(true)}
+            >
+              アカウント削除
+            </button>
           </div>
         </div>
-      )}
+      </div>
       {imageCropModalOpen && (
         <SettingsImageCropModal
           imageUrl={inputImageUrl}

--- a/src/features/profile/settings/components/SettingsPresenter.tsx
+++ b/src/features/profile/settings/components/SettingsPresenter.tsx
@@ -99,7 +99,8 @@ export const SettingsPresenter = () => {
             </div>
             <button
               type="submit"
-              className="w-full text-white bg-rhyth-light-blue hover:bg-rhyth-blue focus:ring-4 focus:outline-none focus:ring-blue-300 font-medium rounded-lg text-sm px-5 py-2.5 text-center"
+              className="w-full text-white bg-rhyth-light-blue hover:bg-rhyth-blue disabled:bg-rhyth-light-gray focus:ring-4 focus:outline-none focus:ring-blue-300 font-medium rounded-lg text-sm px-5 py-2.5 text-center"
+              disabled={updateUserMutation.isPending}
             >
               保存
             </button>

--- a/src/features/quests/api/quest/hooks/useMutateQuest.ts
+++ b/src/features/quests/api/quest/hooks/useMutateQuest.ts
@@ -4,7 +4,7 @@ import type { Quest } from "../../../../../api/quest/model";
 import type { FinishQuestParams, ForceFinishQuestParams, StartQuestParams } from "../../../../../api/quest/types";
 import { queryClient } from "../../../../../pkg/api/client/queryClient";
 import type { FetchError } from "../../../../../pkg/api/util/fetchError";
-import { notifyFailed, notifySuccess } from "../../../../../pkg/ui/toast";
+import { notifyWithToast } from "../../../../../pkg/ui/toast";
 import { useQueryWeeklyReports } from "../../../../analytics/api/weeklyReport/hooks/useQueryWeeklyReport";
 import { useQueryLoginUser } from "../../../../profile/api/user/hooks/useQueryUser";
 import { useQueryBadgeList } from "../../../../profile/badges/api/badge/hooks/useQueryBadge";
@@ -28,10 +28,10 @@ export const useMutateQuest = () => {
           questList.map((quest) => (quest.id === data.id ? data : quest)),
         );
       }
-      notifySuccess("クエストを開始しました。");
+      notifyWithToast({ status: "success", msg: "クエストを開始しました。" });
     },
     onError: (err: FetchError) => {
-      notifyFailed("処理に失敗しました。");
+      notifyWithToast({ status: "error", msg: "処理に失敗しました。" });
       console.log(err);
     },
   });
@@ -52,10 +52,10 @@ export const useMutateQuest = () => {
       refetchLoginUser();
       refetchWeeklyReports();
       refetchBadgeList();
-      notifySuccess("クエストを終了しました。");
+      notifyWithToast({ status: "success", msg: "クエストを終了しました。" });
     },
     onError: (err: FetchError) => {
-      notifyFailed("処理に失敗しました。");
+      notifyWithToast({ status: "error", msg: "処理に失敗しました。" });
       console.log(err);
     },
   });
@@ -76,10 +76,10 @@ export const useMutateQuest = () => {
       refetchLoginUser();
       refetchWeeklyReports();
       refetchBadgeList();
-      notifySuccess("クエストを強制終了しました。");
+      notifyWithToast({ status: "success", msg: "クエストを強制終了しました。" });
     },
     onError: (err: FetchError) => {
-      notifyFailed("処理に失敗しました。");
+      notifyWithToast({ status: "error", msg: "処理に失敗しました。" });
       console.log(err);
     },
   });

--- a/src/features/quests/api/quest/hooks/useQueryQuest.ts
+++ b/src/features/quests/api/quest/hooks/useQueryQuest.ts
@@ -1,11 +1,11 @@
-import { useQuery } from "@tanstack/react-query";
+import { useSuspenseQuery } from "@tanstack/react-query";
 import { createFactory } from "../../../../../api/quest/factory";
 import type { Quest } from "../../../../../api/quest/model";
 import type { FetchError } from "../../../../../pkg/api/util/fetchError";
 
 export const useQueryQuestList = () => {
   const questFactory = createFactory();
-  return useQuery<Quest[], FetchError>({
+  return useSuspenseQuery<Quest[], FetchError>({
     queryKey: ["quests"],
     queryFn: async () => {
       const quests = await questFactory.listQuests();

--- a/src/features/quests/components/QuestsPresenter.tsx
+++ b/src/features/quests/components/QuestsPresenter.tsx
@@ -1,7 +1,6 @@
 import { useState } from "react";
 import type { Quest } from "../../../api/quest/model";
 import { formatDateJP, getToday, getTodayEn, now } from "../../../pkg/util/dayjs";
-import { Loading, LoadingContainer } from "../../common/components";
 import { useQueryQuestList } from "../api/quest/hooks/useQueryQuest";
 import { QuestBoard } from "./QuestBoard";
 import { QuestBoardNoData } from "./QuestBoardNoData";
@@ -20,10 +19,9 @@ const sortQuestListByTime = (questList: Quest[]) => {
 };
 
 export const QuestsPresenter = () => {
-  const { data: questListData, isLoading } = useQueryQuestList();
+  const { data: questListData } = useQueryQuestList();
 
   const filteredQuestList = filterTodaysQuestListByDayOfTheWeek(questListData ?? []);
-
   const sortedQuestList = sortQuestListByTime(filteredQuestList);
 
   const nextQuestList = sortedQuestList.filter((value) => value.state === "INACTIVE");
@@ -38,72 +36,66 @@ export const QuestsPresenter = () => {
         {formatDateJP(now())}
         {`(${getToday()})`}
       </span>
-      {isLoading ? (
-        <LoadingContainer>
-          <Loading />
-        </LoadingContainer>
-      ) : (
-        <div>
-          <div className="flex gap-2 my-2">
-            <svg
-              className="w-6 h-6 text-rhyth-gray"
-              aria-hidden="true"
-              xmlns="http://www.w3.org/2000/svg"
-              width="24"
-              height="24"
-              fill="none"
-              viewBox="0 0 24 24"
+      <div>
+        <div className="flex gap-2 my-2">
+          <svg
+            className="w-6 h-6 text-rhyth-gray"
+            aria-hidden="true"
+            xmlns="http://www.w3.org/2000/svg"
+            width="24"
+            height="24"
+            fill="none"
+            viewBox="0 0 24 24"
+          >
+            <path
+              stroke="currentColor"
+              strokeLinecap="round"
+              strokeLinejoin="round"
+              strokeWidth="2"
+              d="M19 12H5m14 0-4 4m4-4-4-4"
+            />
+          </svg>
+          <h1 className="font-cp-font text-rhyth-gray tracking-widest">NEXT CHALLENGE</h1>
+        </div>
+        {currentQuest ? <QuestBoard currentQuest={currentQuest} /> : <QuestBoardNoData />}
+        <div className={"flex flex-col w-full mt-6 bg-gray-100 rounded-md"}>
+          <div className="flex items-center">
+            <button
+              type="button"
+              className={`px-4 py-2 text-base font-cp-font tracking-widest font-bold rounded-t-lg ${
+                view === "NEXT"
+                  ? "text-white bg-rhyth-light-blue"
+                  : "bg-white text-rhyth-dark-blue hover:bg-rhyth-hover-light-gray"
+              }`}
+              onClick={() => setView("NEXT")}
             >
-              <path
-                stroke="currentColor"
-                strokeLinecap="round"
-                strokeLinejoin="round"
-                strokeWidth="2"
-                d="M19 12H5m14 0-4 4m4-4-4-4"
-              />
-            </svg>
-            <h1 className="font-cp-font text-rhyth-gray tracking-widest">NEXT CHALLENGE</h1>
+              次のクエスト
+            </button>
+            <button
+              type="button"
+              className={`px-4 py-2 text-base font-cp-font tracking-widest font-bold rounded-t-lg shadow-l-lg ${
+                view === "FINISHED"
+                  ? "text-white bg-rhyth-light-blue"
+                  : "bg-white text-rhyth-dark-blue hover:bg-rhyth-hover-light-gray"
+              }`}
+              onClick={() => setView("FINISHED")}
+            >
+              終了クエスト
+            </button>
           </div>
-          {currentQuest ? <QuestBoard currentQuest={currentQuest} /> : <QuestBoardNoData />}
-          <div className={"flex flex-col w-full mt-6 bg-gray-100 rounded-md"}>
-            <div className="flex items-center">
-              <button
-                type="button"
-                className={`px-4 py-2 text-base font-cp-font tracking-widest font-bold rounded-t-lg ${
-                  view === "NEXT"
-                    ? "text-white bg-rhyth-light-blue"
-                    : "bg-white text-rhyth-dark-blue hover:bg-rhyth-hover-light-gray"
-                }`}
-                onClick={() => setView("NEXT")}
-              >
-                次のクエスト
-              </button>
-              <button
-                type="button"
-                className={`px-4 py-2 text-base font-cp-font tracking-widest font-bold rounded-t-lg shadow-l-lg ${
-                  view === "FINISHED"
-                    ? "text-white bg-rhyth-light-blue"
-                    : "bg-white text-rhyth-dark-blue hover:bg-rhyth-hover-light-gray"
-                }`}
-                onClick={() => setView("FINISHED")}
-              >
-                終了クエスト
-              </button>
-            </div>
-            {view === "NEXT" ? (
-              nextQuestList.slice(1)?.length ? (
-                <QuestList questList={nextQuestList.slice(1)} />
-              ) : (
-                <QuestListNoData view={view} />
-              )
-            ) : finishedQuestList?.length ? (
-              <QuestList questList={finishedQuestList} />
+          {view === "NEXT" ? (
+            nextQuestList.slice(1)?.length ? (
+              <QuestList questList={nextQuestList.slice(1)} />
             ) : (
               <QuestListNoData view={view} />
-            )}
-          </div>
+            )
+          ) : finishedQuestList?.length ? (
+            <QuestList questList={finishedQuestList} />
+          ) : (
+            <QuestListNoData view={view} />
+          )}
         </div>
-      )}
+      </div>
     </>
   );
 };

--- a/src/pkg/ui/toast.ts
+++ b/src/pkg/ui/toast.ts
@@ -2,3 +2,18 @@ import toast from "react-hot-toast";
 
 export const notifySuccess = (msg: string) => toast.success(msg);
 export const notifyFailed = (msg: string) => toast.error(msg);
+export const notifyLoading = (msg: string) => toast.loading(msg);
+
+type Status = "success" | "error" | "loading";
+
+export const notifyWithToast = (options: { status: Status; msg: string }) => {
+  if (options.status === "success") {
+    notifySuccess(options.msg);
+  }
+  if (options.status === "error") {
+    notifyFailed(options.msg);
+  }
+  if (options.status === "loading") {
+    notifyLoading(options.msg);
+  }
+};

--- a/src/routes/analytics/index.lazy.tsx
+++ b/src/routes/analytics/index.lazy.tsx
@@ -1,6 +1,7 @@
 import { createLazyFileRoute } from "@tanstack/react-router";
 import { AnalyticsPresenter } from "../../features/analytics/components/AnalyticsPresenter";
-import { ContentLayout, Header, Menu } from "../../features/common/components";
+import { ContentLayout, Header, Loading, LoadingContainer, Menu } from "../../features/common/components";
+import { Suspense } from "react";
 
 export const Route = createLazyFileRoute("/analytics/")({
   component: () => <Analytics />,
@@ -11,7 +12,15 @@ const Analytics = () => {
     <>
       <Header />
       <ContentLayout>
-        <AnalyticsPresenter />
+        <Suspense
+          fallback={
+            <LoadingContainer>
+              <Loading />
+            </LoadingContainer>
+          }
+        >
+          <AnalyticsPresenter />
+        </Suspense>
       </ContentLayout>
       <Menu />
     </>

--- a/src/routes/manage/edit/index.lazy.tsx
+++ b/src/routes/manage/edit/index.lazy.tsx
@@ -1,7 +1,8 @@
 import { createFileRoute } from "@tanstack/react-router";
 import { z } from "zod";
-import { ContentLayout, Header, Menu } from "../../../features/common/components";
+import { ContentLayout, Header, Loading, LoadingContainer, Menu } from "../../../features/common/components";
 import { EditPresenter } from "../../../features/manage/edit/components/EditPresenter";
+import { Suspense } from "react";
 
 const manageSearchSchema = z.object({
   quest_id: z.string().catch(""),
@@ -18,7 +19,15 @@ const Edit = () => {
     <>
       <Header />
       <ContentLayout>
-        <EditPresenter quest_id={quest_id} />
+        <Suspense
+          fallback={
+            <LoadingContainer>
+              <Loading />
+            </LoadingContainer>
+          }
+        >
+          <EditPresenter quest_id={quest_id} />
+        </Suspense>
       </ContentLayout>
       <Menu />
     </>

--- a/src/routes/manage/index.lazy.tsx
+++ b/src/routes/manage/index.lazy.tsx
@@ -1,7 +1,8 @@
 import { createLazyFileRoute } from "@tanstack/react-router";
-import { ContentLayout, Header, Menu } from "../../features/common/components";
+import { ContentLayout, Header, Loading, LoadingContainer, Menu } from "../../features/common/components";
 import { SearchModalIsOpenProvider } from "../../features/common/contexts/searchModalIsOpenContext";
 import { ManagePresenter } from "../../features/manage/components/ManagePresenter";
+import { Suspense } from "react";
 
 export const Route = createLazyFileRoute("/manage/")({
   component: () => <Manage />,
@@ -12,7 +13,15 @@ const Manage = () => {
     <SearchModalIsOpenProvider>
       <Header />
       <ContentLayout>
-        <ManagePresenter />
+        <Suspense
+          fallback={
+            <LoadingContainer>
+              <Loading />
+            </LoadingContainer>
+          }
+        >
+          <ManagePresenter />
+        </Suspense>
       </ContentLayout>
       <Menu />
     </SearchModalIsOpenProvider>

--- a/src/routes/manage/new/index.lazy.tsx
+++ b/src/routes/manage/new/index.lazy.tsx
@@ -1,6 +1,7 @@
 import { createLazyFileRoute } from "@tanstack/react-router";
-import { ContentLayout, Header, Menu } from "../../../features/common/components";
+import { ContentLayout, Header, Loading, LoadingContainer, Menu } from "../../../features/common/components";
 import { NewPresenter } from "../../../features/manage/new/components/NewPresenter";
+import { Suspense } from "react";
 
 export const Route = createLazyFileRoute("/manage/new/")({
   component: () => <New />,
@@ -11,7 +12,15 @@ const New = () => {
     <>
       <Header />
       <ContentLayout>
-        <NewPresenter />
+        <Suspense
+          fallback={
+            <LoadingContainer>
+              <Loading />
+            </LoadingContainer>
+          }
+        >
+          <NewPresenter />
+        </Suspense>
       </ContentLayout>
       <Menu />
     </>

--- a/src/routes/manage/tags/index.lazy.tsx
+++ b/src/routes/manage/tags/index.lazy.tsx
@@ -1,7 +1,8 @@
 import { createLazyFileRoute } from "@tanstack/react-router";
-import { Header, Menu } from "../../../features/common/components";
+import { Header, Loading, LoadingContainer, Menu } from "../../../features/common/components";
 import { ContentLayout } from "../../../features/common/components/layouts/ContentLayout";
 import { TagsPresenter } from "../../../features/manage/tags/components/TagsPresenter";
+import { Suspense } from "react";
 
 export const Route = createLazyFileRoute("/manage/tags/")({
   component: () => <Tags />,
@@ -12,7 +13,15 @@ const Tags = () => {
     <>
       <Header />
       <ContentLayout>
-        <TagsPresenter />
+        <Suspense
+          fallback={
+            <LoadingContainer>
+              <Loading />
+            </LoadingContainer>
+          }
+        >
+          <TagsPresenter />
+        </Suspense>
       </ContentLayout>
       <Menu />
     </>

--- a/src/routes/profile/badges/index.lazy.tsx
+++ b/src/routes/profile/badges/index.lazy.tsx
@@ -1,6 +1,7 @@
 import { createLazyFileRoute } from "@tanstack/react-router";
-import { ContentLayout, Header, Menu } from "../../../features/common/components";
+import { ContentLayout, Header, Loading, LoadingContainer, Menu } from "../../../features/common/components";
 import { BadgesPresenter } from "../../../features/profile/badges/components/BadgesPresenter";
+import { Suspense } from "react";
 
 export const Route = createLazyFileRoute("/profile/badges/")({
   component: () => <Profile />,
@@ -11,7 +12,15 @@ const Profile = () => {
     <>
       <Header />
       <ContentLayout>
-        <BadgesPresenter />
+        <Suspense
+          fallback={
+            <LoadingContainer>
+              <Loading />
+            </LoadingContainer>
+          }
+        >
+          <BadgesPresenter />
+        </Suspense>
       </ContentLayout>
       <Menu />
     </>

--- a/src/routes/profile/index.lazy.tsx
+++ b/src/routes/profile/index.lazy.tsx
@@ -1,6 +1,7 @@
 import { createLazyFileRoute } from "@tanstack/react-router";
-import { ContentLayout, Header, Menu } from "../../features/common/components";
+import { ContentLayout, Header, Loading, LoadingContainer, Menu } from "../../features/common/components";
 import { ProfilePresenter } from "../../features/profile/components/ProfilePresenter";
+import { Suspense } from "react";
 
 export const Route = createLazyFileRoute("/profile/")({
   component: () => <Profile />,
@@ -11,7 +12,15 @@ const Profile = () => {
     <>
       <Header />
       <ContentLayout>
-        <ProfilePresenter />
+        <Suspense
+          fallback={
+            <LoadingContainer>
+              <Loading />
+            </LoadingContainer>
+          }
+        >
+          <ProfilePresenter />
+        </Suspense>
       </ContentLayout>
       <Menu />
     </>

--- a/src/routes/profile/settings/index.lazy.tsx
+++ b/src/routes/profile/settings/index.lazy.tsx
@@ -1,6 +1,7 @@
 import { createLazyFileRoute } from "@tanstack/react-router";
-import { ContentLayout, Header, Menu } from "../../../features/common/components";
+import { ContentLayout, Header, Loading, LoadingContainer, Menu } from "../../../features/common/components";
 import { SettingsPresenter } from "../../../features/profile/settings/components/SettingsPresenter";
+import { Suspense } from "react";
 
 export const Route = createLazyFileRoute("/profile/settings/")({
   component: () => <Profile />,
@@ -11,7 +12,15 @@ const Profile = () => {
     <>
       <Header />
       <ContentLayout>
-        <SettingsPresenter />
+        <Suspense
+          fallback={
+            <LoadingContainer>
+              <Loading />
+            </LoadingContainer>
+          }
+        >
+          <SettingsPresenter />
+        </Suspense>
       </ContentLayout>
       <Menu />
     </>

--- a/src/routes/quests/index.lazy.tsx
+++ b/src/routes/quests/index.lazy.tsx
@@ -1,6 +1,7 @@
 import { createLazyFileRoute } from "@tanstack/react-router";
-import { ContentLayout, Header, Menu } from "../../features/common/components";
+import { ContentLayout, Header, Loading, LoadingContainer, Menu } from "../../features/common/components";
 import { QuestsPresenter } from "../../features/quests/components/QuestsPresenter";
+import { Suspense } from "react";
 
 export const Route = createLazyFileRoute("/quests/")({
   component: () => <Quests />,
@@ -11,7 +12,15 @@ const Quests = () => {
     <>
       <Header />
       <ContentLayout>
-        <QuestsPresenter />
+        <Suspense
+          fallback={
+            <LoadingContainer>
+              <Loading />
+            </LoadingContainer>
+          }
+        >
+          <QuestsPresenter />
+        </Suspense>
       </ContentLayout>
       <Menu />
     </>


### PR DESCRIPTION
## 関連 issue
- close #223 

## 説明
- せっかくなので、reactの`<Suspense />`を利用したAPI通信のハンドリングを実装しました。Suspenseはreactからpromiseがthrowされると、UIのレンダリングをストップし、代わりに`fallback={}`の中身をレンダリングします（=ローディングのUIのこと）Promiseが解決されると、中身のコンポーネントを再レンダリングすることでUIが表示されるというわけです。ざっくりと。
- トーストを表示する関数の汎用ラッパーを作りました。

## 動作確認手順
- いつも通り立ち上げて動かしてもらって、普通に動作確認できれば問題ないです。

## 相談したいこと

## 確認して欲しいこと

## 参考 URL 等
